### PR TITLE
cleanup: one read path for member goals, platform-owned default coaches

### DIFF
--- a/docs/multi-domain-coaches.md
+++ b/docs/multi-domain-coaches.md
@@ -50,6 +50,13 @@ for SMS".
 'listed'` when an approved creator stands behind it, enforced by a trigger so
 the rule holds regardless of which RLS policy admitted the write.
 
+One creator is the platform itself: slug `cabo`, `user_id IS NULL`, no payout
+share. The five original fitness personas (Zen Master, Gym Bro, Dance Teacher,
+Drill Sergeant, Frat Bro) belong to it, because they ship with the product
+rather than being anyone's work. They were seeded against the founder's own
+account and so were attributed to them personally in the roster until
+`20260811090100`.
+
 ### Identity
 
 `user_profiles.user_id` references `auth.users`, phone became optional and E.164
@@ -87,8 +94,9 @@ access.
 | `20260810120000_generalize_coach_domain.sql` | Categories, domain columns, roster search, backfill |
 | `20260810120100_creators_and_coach_subscriptions.sql` | Creators, entitlements, store products, `has_coach_access`, `get_coach_roster` |
 | `20260810120200_app_identity_and_conversations.sql` | `auth.users` identity, conversations, `open_coach_conversation`, `get_my_coaches` |
+| `20260811090100_platform_creator_for_default_coaches.sql` | The `cabo` platform creator; the five default coaches repointed at it |
 
-All three are idempotent and verified by applying the full migration chain from
+All of them are idempotent and verified by applying the full migration chain from
 scratch against Postgres 16 + pgvector.
 
 `supabase/seeds/example_roster.sql` seeds a drummer, a songwriter and a yoga

--- a/docs/prompts-and-notifications.md
+++ b/docs/prompts-and-notifications.md
@@ -99,6 +99,15 @@ call writes the reply and extracts what it learned, under a strict JSON schema.
 - The member can correct anything at `goals/[coachId]`, because extraction will
   sometimes be subtly wrong.
 
+**One read path.** `get_member_context(p_user_id, p_coach_id)` is how goal data
+is read — by the prompt, by the visualiser, and by the app's `fetchGoals()`. It
+is `SECURITY DEFINER` with an ownership guard: a member may only ask for their
+own context, the service role may ask for anyone (it is acting for the member
+inside the functions), and `anon` cannot call it at all. It is also the only
+reader that can compute `days_together`, which needs the entitlement row, and it
+returns `goal_id`, so a null there means "the intake has never run". Writes are
+the other direction: the app updates `member_goals` directly under RLS.
+
 Creators author their own intake in `coach_profiles.onboarding_questions`, so a
 drum teacher asks different questions than a songwriter.
 
@@ -133,6 +142,7 @@ prompted toward *weak, frail, sad, nervous, skinny, chubby, overweight*.
 | ---- | -------- |
 | `20260810130000_push_notifications_and_channels.sql` | `push_devices`, notification channel + timing, per-coach cadence, `coach_nudges` outbox, unread state, realtime, `due_coach_nudges()` |
 | `20260810140000_member_goals_and_visualization.sql` | `member_goals`, creator intake questions, `prompt_version`, `coach_visualizations`, `get_member_context()` |
+| `20260811090000_member_context_read_path.sql` | `get_member_context()` guarded by `auth.uid()`, opened to `authenticated`, closed to `anon`, and returning `goal_id` |
 
 Verified by applying the full chain from scratch against Postgres 16 + pgvector
 and exercising the rules: device gating, idempotent claim, mute, cadence
@@ -203,5 +213,3 @@ Not verified, and why:
 - **Visualisation has no reference-photo upload flow** in the app, so every
   image currently renders scene-only. `user_profiles.reference_photo_url` and
   `likeness_consent` are wired but unpopulated.
-- **`get_member_context` is service-role only**, so the app reads
-  `member_goals` directly under RLS. Two paths to the same data.

--- a/functions/coach-visualizer/index.js
+++ b/functions/coach-visualizer/index.js
@@ -171,13 +171,6 @@ async function handleGenerate(req, res) {
     .eq('user_id', caller.id)
     .maybeSingle();
 
-  const { data: goalRow } = await supabase
-    .from('member_goals')
-    .select('id')
-    .eq('user_id', caller.id)
-    .eq('coach_id', coachId)
-    .maybeSingle();
-
   const scene = await generateScene({ openai, model: CHAT_MODEL, coach, member, kind });
 
   const { data: record, error: insertError } = await supabase
@@ -185,7 +178,9 @@ async function handleGenerate(req, res) {
     .insert({
       user_id: caller.id,
       coach_id: coachId,
-      goal_id: goalRow?.id ?? null,
+      // get_member_context already carries the goals row id, so this does not
+      // need a second query for it.
+      goal_id: member.goal_id ?? null,
       kind,
       scene: scene.scene,
       image_prompt: scene.image_prompt,

--- a/mobile/app/goals/[coachId].tsx
+++ b/mobile/app/goals/[coachId].tsx
@@ -4,7 +4,7 @@ import { useFocusEffect, useLocalSearchParams, useRouter } from 'expo-router';
 import { EmptyState, Loading, Screen } from '@/components/Screen';
 import { fetchCoach, fetchGoals, updateGoals } from '@/lib/api';
 import { theme, tintForCategory } from '@/lib/theme';
-import type { MemberGoals, RosterCoach } from '@/lib/types';
+import type { MemberContext, RosterCoach } from '@/lib/types';
 
 /**
  * What the coach believes about you, and a way to correct it.
@@ -18,7 +18,7 @@ export default function GoalsScreen() {
   const router = useRouter();
 
   const [coach, setCoach] = useState<RosterCoach | null>(null);
-  const [goals, setGoals] = useState<MemberGoals | null>(null);
+  const [goals, setGoals] = useState<MemberContext | null>(null);
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
 
@@ -85,9 +85,16 @@ export default function GoalsScreen() {
   return (
     <Screen edges={['bottom']}>
       <ScrollView contentContainerStyle={styles.content} keyboardDismissMode="on-drag">
-        <Text style={styles.intro}>
-          This is what {coach?.name} is working from. Change anything that isn&apos;t right.
-        </Text>
+        <View style={styles.header}>
+          <Text style={styles.intro}>
+            This is what {coach?.name} is working from. Change anything that isn&apos;t right.
+          </Text>
+          {goals.days_together > 0 ? (
+            <Text style={styles.together}>
+              {goals.days_together} {goals.days_together === 1 ? 'day' : 'days'} together.
+            </Text>
+          ) : null}
+        </View>
 
         <Field
           label="What you want to become"
@@ -190,10 +197,17 @@ const styles = StyleSheet.create({
     gap: theme.space(6),
     paddingBottom: theme.space(12),
   },
+  header: {
+    gap: theme.space(2),
+  },
   intro: {
     color: theme.color.textMuted,
     fontSize: theme.font.body,
     lineHeight: 22,
+  },
+  together: {
+    color: theme.color.textFaint,
+    fontSize: theme.font.small,
   },
   field: {
     gap: theme.space(2),

--- a/mobile/app/visualize/[coachId].tsx
+++ b/mobile/app/visualize/[coachId].tsx
@@ -21,7 +21,7 @@ import {
   setVisualizationSaved,
 } from '@/lib/api';
 import { theme, tintForCategory } from '@/lib/theme';
-import type { MemberGoals, RosterCoach, Visualization } from '@/lib/types';
+import type { MemberContext, RosterCoach, Visualization } from '@/lib/types';
 
 const KINDS: Array<{ key: 'becoming' | 'milestone' | 'today'; label: string; blurb: string }> = [
   { key: 'becoming', label: 'Becoming', blurb: 'You, once you get there' },
@@ -36,7 +36,7 @@ export default function VisualizeScreen() {
   const router = useRouter();
 
   const [coach, setCoach] = useState<RosterCoach | null>(null);
-  const [goals, setGoals] = useState<MemberGoals | null>(null);
+  const [goals, setGoals] = useState<MemberContext | null>(null);
   const [images, setImages] = useState<Visualization[]>([]);
   const [kind, setKind] = useState<'becoming' | 'milestone' | 'today'>('becoming');
   const [loading, setLoading] = useState(true);

--- a/mobile/e2e/rls-probe.mjs
+++ b/mobile/e2e/rls-probe.mjs
@@ -119,11 +119,39 @@ let conversationId;
   const { data: subs, error: subErr } = await user.from('coach_subscriptions').select('source,status,free_message_quota').eq('coach_id', POCKET);
   check('free tier created', !subErr && subs?.[0]?.source === 'free_tier', subErr?.message ?? JSON.stringify(subs));
 
+  // get_member_context() is the one read path for goal data: the prompt, the
+  // visualiser and fetchGoals() all read this shape. A null goal_id is how the
+  // app tells "the intake has never run" from "it ran and found nothing".
+  const { data: before, error: beforeErr } = await user.rpc('get_member_context', {
+    p_user_id: userId, p_coach_id: POCKET,
+  });
+  check('get_member_context before intake → goal_id null', !beforeErr && before?.goal_id === null,
+        beforeErr?.message ?? JSON.stringify(before));
+
   const { data: goalId, error: goalErr } = await user.rpc('begin_goal_onboarding', { p_coach_id: POCKET });
   check('begin_goal_onboarding', !goalErr && !!goalId, goalErr?.message);
 
+  const { data: ctx, error: ctxErr } = await user.rpc('get_member_context', {
+    p_user_id: userId, p_coach_id: POCKET,
+  });
+  check('member reads own context (what fetchGoals calls)', !ctxErr && ctx?.goal_id === goalId,
+        ctxErr?.message ?? JSON.stringify(ctx));
+  check('  → onboarding_status carried', ctx?.onboarding_status === 'in_progress', JSON.stringify(ctx?.onboarding_status));
+  check('  → days_together computed', typeof ctx?.days_together === 'number' && ctx.days_together >= 0,
+        JSON.stringify(ctx?.days_together));
+
+  const { data: svcCtx, error: svcErr } = await admin.rpc('get_member_context', {
+    p_user_id: userId, p_coach_id: POCKET,
+  });
+  check('service role reads any member (the Cloud Functions path)', !svcErr && svcCtx?.goal_id === goalId, svcErr?.message);
+
+  const { error: anonCtxErr } = await anon.rpc('get_member_context', { p_user_id: userId, p_coach_id: POCKET });
+  check('anon may NOT read a member context', !!anonCtxErr, anonCtxErr ? '' : 'call succeeded!');
+
+  // The row itself stays readable under RLS because the app writes to it.
   const { data: goals, error: gErr } = await user.from('member_goals').select('*').eq('coach_id', POCKET).maybeSingle();
-  check('member can read own goals', !gErr && goals?.onboarding_status === 'in_progress', gErr?.message ?? JSON.stringify(goals));
+  check('member_goals row visible under RLS (the write path)', !gErr && goals?.onboarding_status === 'in_progress',
+        gErr?.message ?? JSON.stringify(goals));
 }
 
 section('Message write permissions');
@@ -228,6 +256,12 @@ section('Cross-tenant isolation');
 
   const { data: theirGoals } = await otherClient.from('member_goals').select('id');
   check('another member cannot read these goals', (theirGoals?.length ?? 0) === 0, JSON.stringify(theirGoals));
+
+  // SECURITY DEFINER bypasses the policy above, so the function guards itself.
+  const { error: crossCtxErr } = await otherClient.rpc('get_member_context', {
+    p_user_id: userId, p_coach_id: POCKET,
+  });
+  check('another member cannot read this context', !!crossCtxErr, crossCtxErr ? '' : 'call succeeded!');
 
   const { data: theirCoaches } = await otherClient.rpc('get_my_coaches');
   check('get_my_coaches is per-caller', (theirCoaches?.length ?? 0) === 0, JSON.stringify(theirCoaches?.length));

--- a/mobile/src/lib/api.ts
+++ b/mobile/src/lib/api.ts
@@ -2,7 +2,7 @@ import { API_URL, getAccessToken, supabase } from './supabase';
 import type {
   ChatMessage,
   CoachCategory,
-  MemberGoals,
+  MemberContext,
   MyCoach,
   NotificationPreferences,
   NudgeCadence,
@@ -260,23 +260,37 @@ export async function beginGoalOnboarding(coachId: string): Promise<string> {
   return data as string;
 }
 
-export async function fetchGoals(coachId: string): Promise<MemberGoals | null> {
-  const { data, error } = await supabase
-    .from('member_goals')
-    .select(
-      'id, coach_id, aspiration, goals, current_level, obstacles, motivation, horizon, commitment, wins, onboarding_status, onboarding_turns'
-    )
-    .eq('coach_id', coachId)
-    .maybeSingle();
+/**
+ * The one read path for goal data. `get_member_context()` is what the prompt
+ * and the visualiser read, so the app reads it too rather than querying
+ * `member_goals` and ending up with a second, subtly different shape — and it
+ * is the only caller that can compute `days_together`.
+ *
+ * Returns null when the intake has never run, so screens can tell "nothing
+ * recorded yet" from "recorded, but empty".
+ */
+export async function fetchGoals(coachId: string): Promise<MemberContext | null> {
+  const { data: sessionData } = await supabase.auth.getSession();
+  const userId = sessionData.session?.user?.id;
+  if (!userId) return null;
+
+  const { data, error } = await supabase.rpc('get_member_context', {
+    p_user_id: userId,
+    p_coach_id: coachId,
+  });
 
   if (error) throw error;
-  return (data as MemberGoals) ?? null;
+
+  const context = data as MemberContext | null;
+  return context?.goal_id ? context : null;
 }
 
 /** Members can correct anything the intake got wrong. */
 export async function updateGoals(
   coachId: string,
-  patch: Partial<Pick<MemberGoals, 'aspiration' | 'goals' | 'current_level' | 'obstacles' | 'motivation' | 'horizon'>>
+  patch: Partial<
+    Pick<MemberContext, 'aspiration' | 'goals' | 'current_level' | 'obstacles' | 'motivation' | 'horizon'>
+  >
 ): Promise<void> {
   const { error } = await supabase.from('member_goals').update(patch).eq('coach_id', coachId);
   if (error) throw error;

--- a/mobile/src/lib/types.ts
+++ b/mobile/src/lib/types.ts
@@ -72,10 +72,21 @@ export type NudgeCadence = 'daily' | 'few_times_week' | 'weekly' | 'off';
 
 export type NotificationChannel = 'push' | 'sms' | 'none';
 
-/** What the member told this coach they are working toward. */
-export interface MemberGoals {
-  id: string;
-  coach_id: string;
+export type OnboardingStatus = 'not_started' | 'in_progress' | 'complete' | 'skipped';
+
+/**
+ * What the member told this coach they are working toward — the payload of
+ * `get_member_context()`, which is the one read path for this data. The prompt,
+ * the visualiser and the app all see exactly these fields; reading
+ * `member_goals` directly would miss `days_together`, which only the function
+ * can compute (it joins the entitlement row). Writes still go straight to the
+ * table under RLS.
+ */
+export interface MemberContext {
+  /** null until the intake has created the row. */
+  goal_id: string | null;
+  display_name: string | null;
+  timezone: string | null;
   aspiration: string | null;
   goals: string[];
   current_level: string | null;
@@ -84,8 +95,11 @@ export interface MemberGoals {
   horizon: string | null;
   commitment: { days_per_week?: number; minutes_per_session?: number };
   wins: string[];
-  onboarding_status: 'not_started' | 'in_progress' | 'complete' | 'skipped';
+  visual: { self?: string; setting?: string; style?: string; avoid?: string };
+  onboarding_status: OnboardingStatus;
   onboarding_turns: number;
+  /** Days since this coach was first opened. 0 when they only just started. */
+  days_together: number;
 }
 
 export interface Visualization {

--- a/supabase/migrations/20260811090000_member_context_read_path.sql
+++ b/supabase/migrations/20260811090000_member_context_read_path.sql
@@ -1,0 +1,87 @@
+/*
+  # One read path for a member's goals
+
+  `get_member_context()` shipped as `SECURITY DEFINER` granted to `service_role`,
+  so only the Cloud Functions could call it. The app therefore read
+  `member_goals` directly under RLS and got a different shape back — two
+  representations of the same data, drifting apart, and the client's one was
+  missing `days_together`, which only this function computes.
+
+  The function wins, because it is the shape the prompt is written against and
+  it is the only one that can join `coach_subscriptions` for "how long we have
+  been at this". This migration makes it callable by the member themselves:
+
+    1. An ownership guard. `SECURITY DEFINER` bypasses the RLS on
+       `member_goals`, so the check RLS would have made has to be made here:
+       a caller may only ask for their own context. The service role (which
+       carries no `sub` claim, and acts on the member's behalf inside the
+       functions) may still ask for anyone.
+
+    2. EXECUTE revoked from PUBLIC. Postgres grants EXECUTE on a new function
+       to PUBLIC by default, so the original `GRANT ... TO service_role` never
+       actually kept anybody out — `anon` could already have read any member's
+       goals given their user id. The guard above closes that; the REVOKE means
+       an unauthenticated caller cannot even reach it.
+
+    3. `goal_id` added to the payload, so one round trip distinguishes "the
+       intake has never run" from "the row exists but is still empty", which
+       is what the goals screen keys its empty state off. It also saves
+       `coach-visualizer` a second query for the same id.
+
+  Writes are unchanged: the member still updates `member_goals` directly under
+  the "Members manage their own goals" policy.
+*/
+
+CREATE OR REPLACE FUNCTION public.get_member_context(p_user_id uuid, p_coach_id uuid)
+RETURNS jsonb
+LANGUAGE plpgsql
+STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_caller uuid := auth.uid();
+  v_role   text := COALESCE(auth.jwt() ->> 'role', '');
+  v_result jsonb;
+BEGIN
+  IF v_role <> 'service_role' AND (v_caller IS NULL OR v_caller <> p_user_id) THEN
+    RAISE EXCEPTION 'Not authorized to read another member''s context'
+      USING ERRCODE = '42501';
+  END IF;
+
+  SELECT jsonb_build_object(
+      'goal_id',        mg.id,
+      'display_name',   COALESCE(up.display_name, up.full_name),
+      'timezone',       up.timezone,
+      'aspiration',     mg.aspiration,
+      'goals',          COALESCE(mg.goals, '{}'),
+      'current_level',  mg.current_level,
+      'obstacles',      COALESCE(mg.obstacles, '{}'),
+      'motivation',     mg.motivation,
+      'horizon',        mg.horizon,
+      'commitment',     COALESCE(mg.commitment, '{}'::jsonb),
+      'wins',           COALESCE(mg.wins, '{}'),
+      'visual',         COALESCE(mg.visual, '{}'::jsonb),
+      'onboarding_status', COALESCE(mg.onboarding_status, 'not_started'),
+      'onboarding_turns',  COALESCE(mg.onboarding_turns, 0),
+      'days_together',  GREATEST(0, COALESCE(EXTRACT(DAY FROM now() - cs.created_at)::int, 0))
+  )
+  INTO v_result
+  FROM public.user_profiles up
+  LEFT JOIN public.member_goals mg
+         ON mg.user_id = p_user_id AND mg.coach_id = p_coach_id
+  LEFT JOIN public.coach_subscriptions cs
+         ON cs.user_id = p_user_id AND cs.coach_id = p_coach_id
+  WHERE up.user_id = p_user_id
+  LIMIT 1;
+
+  RETURN v_result;
+END;
+$$;
+
+REVOKE ALL    ON FUNCTION public.get_member_context(uuid, uuid) FROM PUBLIC;
+REVOKE ALL    ON FUNCTION public.get_member_context(uuid, uuid) FROM anon;
+GRANT  EXECUTE ON FUNCTION public.get_member_context(uuid, uuid) TO authenticated, service_role;
+
+COMMENT ON FUNCTION public.get_member_context(uuid, uuid)
+    IS 'The single read path for a member''s goals: the prompt, the visualiser and the app all call this. Callers may only ask for themselves; the service role may ask for anyone.';

--- a/supabase/migrations/20260811090100_platform_creator_for_default_coaches.sql
+++ b/supabase/migrations/20260811090100_platform_creator_for_default_coaches.sql
@@ -1,0 +1,80 @@
+/*
+  # The default coaches belong to the platform, not to a person
+
+  `20250531093301_add_predefined_coaches.sql` seeded the five original personas
+  (Zen Master, Gym Bro, Dance Teacher, Drill Sergeant, Frat Bro) against
+  whichever `user_profiles` row belonged to the founder's own phone number, and
+  `20260810120100_creators_and_coach_subscriptions.sql` then backfilled a
+  `creator_profiles` row for every account that owned a coach. Net effect: the
+  platform's own default coaches are attributed to one person's personal
+  account, and `get_coach_roster()` shows their name under all five.
+
+  This introduces a creator that is the platform — `user_id IS NULL`, so it is
+  not tied to any auth account, nobody can sign in "as" it, and the
+  "creator always has access to their own coaches" branch of `has_coach_access`
+  cannot match it — and repoints the five seeded coaches at it.
+
+  What this deliberately does not touch: `coach_profiles.user_email`, which is
+  `NOT NULL REFERENCES user_profiles(email)` and therefore cannot be pointed at
+  an account that does not exist. Attribution in the roster comes from
+  `creator_id`, which is what this fixes; `user_email` stays as the legacy
+  owner link that the pre-creator RLS policies still read.
+
+  Idempotent, and a no-op in three separate ways: on a database where the seed
+  never ran (the original migration skips itself when that phone number is
+  absent, so the five rows may not exist at all), on a re-run, and if the
+  `cabo` slug has somehow been claimed by a real creator.
+*/
+
+DO $$
+DECLARE
+  -- Fixed so re-runs and other environments converge on the same row.
+  v_platform_id  uuid := '00000000-0000-4000-8000-0000000000ca';
+  v_creator_id   uuid;
+  v_repointed    integer;
+BEGIN
+  INSERT INTO public.creator_profiles (
+      id, user_id, user_email, display_name, slug, bio, status, revenue_share_bps
+  )
+  SELECT
+      v_platform_id,
+      NULL,
+      -- Not a mailbox anyone signs in with; the column is NOT NULL and is only
+      -- used for payout correspondence, which the platform does not need.
+      'coaches@cabo.fit',
+      'Cabo',
+      'cabo',
+      'The default coaches that ship with Cabo.',
+      'approved',
+      -- The platform is not paying itself a creator share.
+      0
+  WHERE NOT EXISTS (
+      SELECT 1 FROM public.creator_profiles WHERE id = v_platform_id OR slug = 'cabo'
+  );
+
+  SELECT id INTO v_creator_id
+  FROM public.creator_profiles
+  WHERE id = v_platform_id AND user_id IS NULL;
+
+  IF v_creator_id IS NULL THEN
+    RAISE NOTICE 'Platform creator not available (slug "cabo" is held by someone else); leaving coach attribution alone.';
+    RETURN;
+  END IF;
+
+  UPDATE public.coach_profiles
+  SET creator_id = v_creator_id
+  WHERE id IN (
+      '11111111-1111-1111-1111-111111111111',  -- Zen Master
+      '22222222-2222-2222-2222-222222222222',  -- Gym Bro
+      '33333333-3333-3333-3333-333333333333',  -- Dance Teacher
+      '44444444-4444-4444-4444-444444444444',  -- Drill Sergeant
+      '55555555-5555-5555-5555-555555555555'   -- Frat Bro
+    )
+    AND creator_id IS DISTINCT FROM v_creator_id;
+
+  GET DIAGNOSTICS v_repointed = ROW_COUNT;
+  RAISE NOTICE 'Default coaches repointed at the platform creator: %', v_repointed;
+END $$;
+
+COMMENT ON TABLE public.creator_profiles
+    IS 'People who publish coaches on the platform and get paid for them. The row with user_id IS NULL and slug ''cabo'' is the platform itself, which owns the default coaches.';


### PR DESCRIPTION
Closes #16. Two independent leftovers, one PR.

## 1. One read path for member-goal data

**Decision: the RPC wins.** `get_member_context(p_user_id, p_coach_id)` is now granted to `authenticated` behind an ownership guard, and `fetchGoals()` calls it instead of selecting `member_goals` directly.

Why that way round rather than documenting the split:

- It is the shape the prompt is written against (`coach-prompt-v2.js` renders it), so keeping a second client-side shape means two things to update every time the intake learns a new field.
- It is the only reader that can compute `days_together` — that needs a join onto `coach_subscriptions`, which the direct read does not do. The goals screen now shows it ("14 days together.").
- Closing it off was not actually closing it off. Postgres grants `EXECUTE` on a new function to `PUBLIC` by default, so the original `GRANT ... TO service_role` kept nobody out: `anon` could read any member's goals given their user id. Opening it deliberately meant writing the guard that should always have been there.

`20260811090000_member_context_read_path.sql`:

- `RAISE EXCEPTION` unless the caller is asking for themselves. `SECURITY DEFINER` bypasses the `member_goals` policy, so the check RLS would have made is made in the function. The service role (no `sub` claim, acting for the member inside the Cloud Functions) may still ask for anyone.
- `REVOKE ALL ... FROM PUBLIC, anon`; `GRANT EXECUTE ... TO authenticated, service_role`.
- Adds `goal_id` to the payload, so one round trip distinguishes "the intake has never run" from "it ran and found nothing" — which is what the goals screen keys its empty state off. `coach-visualizer` drops its separate query for the same id.

Writes are unchanged and still go straight to `member_goals` under the "Members manage their own goals" policy — the split that remains is read-through-function / write-through-RLS, which is deliberate and now documented in `docs/prompts-and-notifications.md`.

`mobile/src/lib/types.ts`: `MemberGoals` becomes `MemberContext`, describing exactly what the function returns (`goal_id`, `days_together`, `display_name`, `timezone`, `visual` included).

## 2. The default coaches belong to the platform

The 2025 seed attached Zen Master, Gym Bro, Dance Teacher, Drill Sergeant and Frat Bro to one specific `user_profiles` row, and `…120100` then backfilled a `creator_profiles` row for every account that owned a coach — so the platform's own default coaches showed up in `get_coach_roster()` under an individual's name.

`20260811090100_platform_creator_for_default_coaches.sql` adds a creator that is the platform — fixed id, `slug = 'cabo'`, `user_id IS NULL` (so no account can sign in as it, and the "a creator always has access to their own coaches" branch of `has_coach_access` cannot match it), `revenue_share_bps = 0` — and repoints the five fixed coach UUIDs at it.

It leaves `coach_profiles.user_email` alone: that column is `NOT NULL REFERENCES user_profiles(email)` and cannot point at an account that does not exist. Roster attribution comes from `creator_id`, which is what this fixes. The legacy phone/email RLS policies on `coach_profiles` still read `user_email`; untangling those is a separate job.

Safe in three ways: no-op when the personas were never seeded (the original migration skips itself when that account is absent, so the rows may not exist at all), no-op on re-run, and no-op if the `cabo` slug has been claimed by a real creator (it raises a notice and leaves attribution alone rather than pointing the defaults at a stranger).

## Verification

Local Supabase on a private port range plus the function gateway and the mock model, per `mobile/e2e/README.md`:

- `mobile/e2e/rls-probe.mjs` — 48 passed, 0 failed. Seven new checks around the read path: `goal_id` null before the intake and set after, `onboarding_status` and `days_together` carried, the service role reading any member (the functions path), `anon` refused, and a second member refused when asking for someone else's context.
- `mobile/e2e/flow-probe.mjs` — 34 passed, 0 failed.
- `mobile/e2e/viz-realtime-probe.mjs` — 17 passed, 0 failed. Confirmed the generated row carries `goal_id` from the RPC rather than the removed query.
- Full migration chain from scratch against `pgvector/pgvector:pg16` + `harness/supabase-shim.sql`: all 19 apply clean.
- Item 2 exercised against a fixture that reproduces the seeded state: 5 coaches repointed, roster then shows `creator_name = Cabo` / `creator_slug = cabo` for all five, re-run repoints 0, one platform creator row with a null `user_id`.
- `cd mobile && npx tsc --noEmit` clean; `node --check functions/coach-visualizer/index.js`; `cd _infra && terraform validate` — "The configuration is valid."

🤖 Generated with [Claude Code](https://claude.com/claude-code)
