### PR TITLE
deploy: fix two migration backfill defects and stage the multi-domain backend rollout

### DIFF
--- a/_infra/terraform.tfvars.example
+++ b/_infra/terraform.tfvars.example
@@ -43,6 +43,25 @@ conversation_bucket_location = "US"
 coach_content_bucket_name    = "coach-content"
 coach_content_bucket_location = "US"
 
+# Multi-domain coach backend
+# internal_service_key is the shared secret for service-to-service calls. The
+# SAME value must reach coach-response-generator and coach-nudges, or the
+# dispatcher's suppressUserTurn / onBehalfOfUserId calls are rejected with 403.
+# Generate with: openssl rand -hex 32
+internal_service_key      = "generate-with-openssl-rand-hex-32"
+# Only needed if push security is enabled on the Expo project.
+expo_access_token         = ""
+nudge_batch_size          = "100"
+openai_chat_model         = "gpt-4o-mini"
+visualization_daily_limit = "3"
+
+# In-app purchases. iap-validator fails closed while apple_root_certs_base64 is
+# empty, which is the intended state until the App Store app record exists.
+# Generate the certs with scripts/fetch-apple-root-certs.sh
+apple_bundle_id         = "fit.cabo.app"
+apple_app_apple_id      = ""
+apple_root_certs_base64 = ""
+
 # Container Configuration
 repository_name = "workout-app"
 image_name      = "workout-webapp" 

--- a/supabase/migrations/20260810120100_creators_and_coach_subscriptions.sql
+++ b/supabase/migrations/20260810120100_creators_and_coach_subscriptions.sql
@@ -463,6 +463,12 @@ CREATE POLICY "Users can start a free tier for themselves"
 
 GRANT SELECT, INSERT         ON public.coach_subscriptions TO authenticated;
 GRANT SELECT                 ON public.coach_iap_products  TO anon, authenticated;
+-- anon needs SELECT for the "Anyone can view approved creators" policy above to
+-- mean anything: table grants are checked before RLS, so without this the
+-- logged-out coach detail page fails with "permission denied for table
+-- creator_profiles" on its embedded creator join. RLS still restricts anon to
+-- rows with status = 'approved'.
+GRANT SELECT                 ON public.creator_profiles    TO anon;
 GRANT SELECT, INSERT, UPDATE ON public.creator_profiles    TO authenticated;
 GRANT ALL ON public.creator_profiles    TO service_role;
 GRANT ALL ON public.coach_iap_products  TO service_role;

--- a/supabase/migrations/20260810140000_member_goals_and_visualization.sql
+++ b/supabase/migrations/20260810140000_member_goals_and_visualization.sql
@@ -90,7 +90,11 @@ ALTER TABLE public.coach_profiles
     */
     ADD COLUMN IF NOT EXISTS onboarding_questions text[] DEFAULT '{}',
     -- 'v1' is the 2024 single-string prompt; 'v2' is the rebuilt one.
-    ADD COLUMN IF NOT EXISTS prompt_version       text DEFAULT 'v2',
+    -- Deliberately added WITHOUT a default: a default would be materialised into
+    -- every existing row, so the 'v1' backfill below could never match and every
+    -- coach already in production would be silently switched to the v2 prompt.
+    -- The default is set to 'v2' after the backfill instead.
+    ADD COLUMN IF NOT EXISTS prompt_version       text,
     -- Creator opt-out: some coaches are drop-in, not goal-driven.
     ADD COLUMN IF NOT EXISTS collects_goals       boolean DEFAULT true NOT NULL,
     ADD COLUMN IF NOT EXISTS supports_visualization boolean DEFAULT true NOT NULL;
@@ -106,6 +110,10 @@ END $$;
 -- Existing coaches keep the prompt they were tuned against; only new rows
 -- default to v2. Flip a coach with: update coach_profiles set prompt_version='v2'.
 UPDATE public.coach_profiles SET prompt_version = 'v1' WHERE prompt_version IS NULL;
+
+-- Only now does 'v2' become the default, so it applies to rows created from
+-- here on rather than retroactively to the existing roster.
+ALTER TABLE public.coach_profiles ALTER COLUMN prompt_version SET DEFAULT 'v2';
 
 UPDATE public.coach_profiles SET onboarding_questions = ARRAY[
     'What are you hoping to be able to do that you can''t do yet?',


### PR DESCRIPTION
## Status: staged and verified, **not applied**

I could not complete the live apply. The Supabase CLI on this machine is authenticated as an account with no access to the project (`supabase projects list` returns an empty set; `migration list --linked` and `db push` both fail with `LegacyDbConfigLoginRoleStatusError ... 403 Your account does not have the necessary privileges`). The direct-`--db-url` route needs the database password, which is not in `_infra/terraform.tfvars` and which I did not go hunting for in the OS keychain.

Because of that I also **did not run `terraform apply`**, deliberately — see [Why terraform was not applied](#why-terraform-was-not-applied). Everything else in the issue is done, and the apply is now a two-command operation for whoever holds the credentials.

Closes #5 for the review-and-fix work. The live apply still has to happen; see the checklist at the bottom.

---

## What I found (step 1: review the backfills)

Reviewing the six migrations against **live data** turned up two defects that only bite on a database that already has rows — which is why local testing never caught them. Both are fixed in this PR.

### 1. `prompt_version` pinned every existing coach to `v2`, not `v1`

`20260810140000` added the column as `text DEFAULT 'v2'`. Postgres materialises a non-volatile default into every existing row at `ADD COLUMN` time, so the backfill on the next line —

```sql
UPDATE public.coach_profiles SET prompt_version = 'v1' WHERE prompt_version IS NULL;
```

— matched **zero rows**. Every coach already in production would have been silently switched to the rebuilt v2 prompt.

The migration's own comment and the issue text both state the opposite intent: *"`prompt_version` pins existing coaches to `'v1'`, both deliberate so current SMS users are unaffected."* This was a live behaviour change for existing SMS users, disguised as a no-op.

Fixed with the same add → backfill → set-default ordering that `20260810130000` already uses correctly for `notification_channel`. Verified on a pg15 container:

```
=== handle | prompt_version (legacy MUST be v1, new MUST be v2) ===
 legacy_coach | v1
 new_coach    | v2
=== idempotency: re-apply 140000 ===
 legacy_coach | v1
 new_coach    | v2
```

### 2. `anon` could not read `creator_profiles`

`20260810120100` creates a policy named **"Anyone can view approved creators"** but only grants `SELECT` to `authenticated`. Table grants are checked *before* RLS, so the policy could never fire for a logged-out visitor — the public coach detail page failed with `permission denied for table creator_profiles` on its embedded creator join. This is exactly what `rls-probe.mjs` asserts.

Granting `SELECT` to `anon` makes the policy mean what it says. RLS still restricts anon to `status = 'approved'`.

### `notification_channel` — reviewed, correct as written

`20260810130000` sets every existing row to `'sms'` and *then* flips the column default to `'push'`, so only new signups get push. Correct ordering, idempotent, and the sequencing comment matches the code. No change needed. This is the pattern the `prompt_version` fix above copies.

### One live-data risk checked and cleared

The creator backfill at `20260810120100:62-81` inserts `user_profiles.id` into `creator_profiles.user_id`, which is `REFERENCES auth.users(id)`. Those two ids are only equal for profiles created via `handle_new_user()`; rows from `create_user_with_trial()` get a bare `gen_random_uuid()`. A single mismatched coach owner would abort the migration and leave the schema half-applied.

I checked this against the live project before concluding anything:

```
coach_profiles rows: 9
distinct coach owner emails: 1
auth.users count: 3
=== FK CHECK: coach owners whose user_profiles.id is NOT an auth.users.id ===
violations: 0 / 1
>>> FK backfill is SAFE on current live data <<<
```

One owner, and their profile id is a valid auth id. **Safe to apply today** — but it is fragile, and a second creator signing up through the trial path before the apply would break it. Worth hardening separately.

---

## Security: do not apply the six migrations without the seventh

`get_member_context()` in `20260810140000` is `SECURITY DEFINER`. Postgres grants `EXECUTE` on a new function to `PUBLIC` by default, so the `GRANT ... TO service_role` in that migration keeps **nobody** out. `anon` — a key that ships in the public web bundle — can read any member's goals given a user id.

I reproduced it end to end on a local stack running the exact migration chain in this PR:

```
=== function ACL — the "=X/postgres" entry is PUBLIC EXECUTE ===
 get_member_context | {=X/postgres,postgres=X/postgres,service_role=X/postgres}

ANON call -> HTTP 200
{"wins": [], "goals": [], "visual": {}, "horizon": null, "timezone": "UTC",
 "obstacles": [], "aspiration": "PRIVATE: I want to quit my job and drum full time",
 "commitment": {}, "motivation": "PRIVATE MOTIVATION", "display_name": "Victim Person",
 "current_level": "beginner", "days_together": 0, "onboarding_turns": 0,
 "onboarding_status": "complete"}
```

**Nothing is exposed right now** — I confirmed `public.get_member_context` does not exist on the live project (PostgREST returns `PGRST202`), and since the migrations were never applied, the vulnerable grant was never created. The window is entirely in the hands of whoever runs the apply.

The fix is `supabase/migrations/20260811090000_member_context_read_path.sql`, which lives on `cleanup/leftovers-round-1` (**PR #18**, open and unmerged). I verified it closes the hole completely:

```
=== ACL after fix — no PUBLIC entry ===
 {postgres=X/postgres,service_role=X/postgres,authenticated=X/postgres}

anon                              -> HTTP 401  permission denied for function get_member_context
authenticated attacker -> victim  -> HTTP 403  Not authorized to read another member's context
authenticated attacker -> self    -> HTTP 200
service_role -> victim            -> HTTP 200  (Cloud Functions still work)
```

It is idempotent. **Whoever runs the apply must apply it in the same session, immediately after `20260810140000`**, so the vulnerable grant is never live. That leaves the live database briefly carrying a migration that is not yet on `main` — the correct trade, and a reason to merge #18 promptly.

I deliberately did **not** commit that migration to this branch; it belongs to #18 and committing it here would create a duplicate-filename conflict.

---

## Step 2: `internal_service_key`

Generated with `openssl rand -hex 32` and set in `_infra/terraform.tfvars` (gitignored — the value is not in this PR, this commit, or any log). Terraform wires the same variable into both `coach-response-generator` and `coach-nudges`, so both ends match by construction.

All eight new variables now have values. The eight are documented in `terraform.tfvars.example` in this PR.

| Variable | Value | Note |
| --- | --- | --- |
| `internal_service_key` | generated, 32 random bytes hex | real |
| `expo_access_token` | empty | genuinely optional — only needed if push security is enabled on the Expo project |
| `nudge_batch_size` | `100` | real |
| `openai_chat_model` | `gpt-4o-mini` | **choice to confirm** — variable default is `gpt-4o`; I set the model that #4 verified as funded and working, and it is far cheaper. Change if you want `gpt-4o` quality in production. |
| `visualization_daily_limit` | `3` | real |
| `apple_bundle_id` | `fit.cabo.app` | **PLACEHOLDER** — issue #7 |
| `apple_app_apple_id` | empty | **PLACEHOLDER** — issue #7 |
| `apple_root_certs_base64` | empty | **PLACEHOLDER** — issue #7. `iap-validator` fails closed while empty, which is the correct safe state until the App Store record exists. |

---

## Why terraform was not applied

`terraform plan` is clean and does exactly what the issue describes — I ran it read-only:

```
Plan: 29 to add, 6 to change, 5 to destroy.
```

The three new functions, their service accounts, IAM bindings and invokers, and `google_cloud_scheduler_job.hourly_coach_nudges` are all created. The five "destroys" are function source-zip objects being replaced with new content hashes — routine, not data loss.

I stopped short of applying because **the migrations have to land first**, which is the issue's own ordering (step 1 before step 3) and here a hard safety constraint:

- `coach-response-generator` is substantially rewritten and reads `conversations`, `conversation_messages` and `member_goals`, and calls `has_coach_access()`, `consume_free_message()` and `get_member_context()`. None of those exist on the live project — I verified every one returns `42P01` / `PGRST202`.
- The hourly `trigger-coach-nudges` scheduler would start firing against a missing schema every hour from the moment it is created.

Applying terraform alone would degrade a currently-working production system and could not satisfy any of the acceptance criteria. Staged instead.

---

## Smoke tests (step 4)

Run against the full local stack — the real Cloud Function code through the real gateway routing, against the real migration chain in this PR — with **real `gpt-4o-mini` output** (issue #4's key, verified working). These are *not* live-deployment outputs, because there is no deployment.

**`/coach-response-generator`** — a real chat turn:

```json
{
    "success": true,
    "response": "Slow it down until it's boring. Focus on playing fills at half speed, then gradually speed up while staying in the pocket. What fill are you working on?",
    "metadata": {
        "coachName": "Pocket",
        "discipline": "Drum set — groove, timing and feel",
        "responseStyle": "tough_love",
        "emotionalNeed": "advice",
        "sessionContext": "stuck_on_a_fill",
        "presentation": "sms",
        "promptVersion": "v2",
        "model": "gpt-4o-mini",
        "responseLength": 152,
        "latencyMs": 1830
    }
}
```

Domain-specific drumming coaching, not generic fitness motivation — the multi-domain generalisation works end to end.

**`/coach-nudges/dispatch`**:

```json
{"success":true,"considered":0,"sent":0}
```

**`/coach-visualizer/history`** (it is `POST`, not `GET`):

```json
{"success":true,"visualizations":[]}
```

**`get_coach_roster()`**:

```json
[
    {"name": "Pocket",  "handle": "pocket",       "category": "music",    "discipline": "Drum set — groove, timing and feel"},
    {"name": "Marisol", "handle": "marisol-yoga", "category": "movement", "discipline": "Vinyasa yoga and breathwork"},
    {"name": "June",    "handle": "june-writes",  "category": "creative", "discipline": "Songwriting and lyric craft"}
]
```

**`coach_nudges`** — 2 rows after the probe runs, sane rather than erroring.

---

## Step 5: `supabase_realtime`

On the local stack the guarded block in `20260810130000` works and the publication picks up the table:

```
      pubname      | schemaname |       tablename
-------------------+------------+-----------------------
 supabase_realtime | public     | conversation_messages
```

**This still has to be confirmed on the live project after the apply.** The block is doubly guarded and skips with a `RAISE NOTICE` if the publication is absent, leaving realtime silently off with nothing in the migration record to say so. Check with:

```sql
select * from pg_publication_tables where pubname = 'supabase_realtime';
```

---

## Verification

| Check | Result |
| --- | --- |
| `cd mobile && npx tsc --noEmit` | clean, exit 0 |
| `node --check` on every changed function | clean |
| `cd _infra && terraform validate` | Success! The configuration is valid. |
| `terraform plan` | 29 add / 6 change / 5 replace, no surprises |
| All 17 migrations from scratch on **pg15** | clean (live runs 15.8.1, not pg16) |
| `rls-probe.mjs` | **41 passed, 0 failed** |
| `flow-probe.mjs` | **34 passed, 0 failed** |
| `viz-realtime-probe.mjs` | **17 passed, 0 failed** |
| Total | **92/92** |

Two notes on getting the probes green, for anyone reproducing:

1. A local stack created by Supabase CLI 2.113 does **not** reproduce hosted Supabase's default privileges — `service_role` ends up without `SELECT` on `user_profiles`, which makes `coach-response-generator` return `Coach not found or inactive` and fails most of `flow-probe`. `GRANT ALL ON ALL TABLES IN SCHEMA public TO anon, authenticated, service_role;` restores parity with hosted. Not a code defect; the live project has the grants.
2. A stale `function-gateway.js` holding port 8790 will silently serve old code. `lsof -i :8790` before trusting a red probe.

---

## Two things I noticed but did not change

- **`match_coach_content` is broken.** Every RAG lookup logs `structure of query does not match function result type — Returned type coach_content_type does not match expected type text in column 3` and returns `[]`. `20260810120000` adds seven values to the `coach_content_type` enum, and the function's `RETURNS TABLE` still declares that column as `text`. The error is caught and swallowed, so coaches answer without any of their uploaded content. Not in scope here, worth its own issue.
- **Re-running `20260810120200` after `20260810130000` fails** (`cannot change return type of existing function` — `get_my_coaches`). Only reachable by re-applying a single migration out of order, which Supabase never does, and it fails loudly rather than silently downgrading the function. Left alone on purpose.

---

## Remaining checklist for whoever holds the credentials

1. `supabase db push` (or `psql`) to apply the six migrations — verify the FK check above still shows `violations: 0` first.
2. **Immediately** apply `20260811090000_member_context_read_path.sql` from `cleanup/leftovers-round-1`, in the same session.
3. `cd _infra && terraform apply`.
4. Re-run the three smoke tests against the deployed URLs.
5. Confirm `supabase_realtime` includes `public.conversation_messages`.
6. Merge PR #18 promptly so `main` catches up with the live schema.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
