### PR TITLE
[creators] Creator onboarding and coach publishing UI (C1)

### DIFF
--- a/_infra/cloud_functions.tf
+++ b/_infra/cloud_functions.tf
@@ -678,7 +678,7 @@ module "admin_api_function" {
   source = "./modules/cloud_function"
 
   name        = "admin-api"
-  description = "Admin API for user management and chat logs"
+  description = "Admin API for user management, chat logs, and creator approval"
   region      = var.region
   bucket_name = google_storage_bucket.function_bucket.name
   source_object = google_storage_bucket_object.admin_api_source.name

--- a/docs/multi-domain-coaches.md
+++ b/docs/multi-domain-coaches.md
@@ -50,6 +50,21 @@ for SMS".
 'listed'` when an approved creator stands behind it, enforced by a trigger so
 the rule holds regardless of which RLS policy admitted the write.
 
+Anyone can sign themselves up at `/creator` in the web app. The form sends only
+the columns a creator owns; `protect_creator_platform_fields()` discards
+`status`, `revenue_share_bps` and the payout columns on **insert as well as
+update**, so a new profile always lands `pending` on the standard split however
+the request was shaped. Approval is a platform action performed by the admin
+dashboard through `admin-api`, which holds the service role key server-side —
+the trigger only stands aside when `auth.uid()` is null.
+
+Publishing walks `draft → in_review → listed` from the coach card in
+`/my-coaches`. Submitting for review always succeeds; reaching the roster does
+not, and the `insufficient_privilege` a pending creator gets back is rendered as
+"your creator account is still under review" rather than as a Postgres error.
+Approving a creator publishes whatever they already queued; suspending one pulls
+their listings back to `unlisted`.
+
 ### Identity
 
 `user_profiles.user_id` references `auth.users`, phone became optional and E.164
@@ -87,9 +102,10 @@ access.
 | `20260810120000_generalize_coach_domain.sql` | Categories, domain columns, roster search, backfill |
 | `20260810120100_creators_and_coach_subscriptions.sql` | Creators, entitlements, store products, `has_coach_access`, `get_coach_roster` |
 | `20260810120200_app_identity_and_conversations.sql` | `auth.users` identity, conversations, `open_coach_conversation`, `get_my_coaches` |
+| `20260811120000_creator_self_signup.sql` | INSERT guard on the platform-owned creator columns, one profile per account, `creator_slug_available`, coach attribution guard |
 
-All three are idempotent and verified by applying the full migration chain from
-scratch against Postgres 16 + pgvector.
+All of them are idempotent and verified by applying the full migration chain
+from scratch against Postgres 16 + pgvector.
 
 `supabase/seeds/example_roster.sql` seeds a drummer, a songwriter and a yoga
 instructor. It is a seed, not a migration — run it by hand on dev/staging.
@@ -102,8 +118,12 @@ instructor. It is a seed, not a migration — run it by hand on dev/staging.
   the copy and the builder form are not.
 - **Google Play billing** is stubbed. `/iap-validator/verify` returns 501 for
   Android rather than granting anything.
-- **Creator onboarding** has no UI. Creating a `creator_profiles` row and
-  approving it is a manual insert today.
+- **Approved creators' payout terms are readable by any signed-in user.**
+  `authenticated` holds table-level `SELECT` on `creator_profiles`, and the
+  "Anyone can view approved creators" policy admits every approved row — so
+  `revenue_share_bps` and `payout_account_id` come with it. `anon` is limited to
+  the public columns; `authenticated` is not, because a creator has to be able
+  to read their own split. Splitting the two needs a view or a definer function.
 - **Revenue split is recorded, not paid.** `revenue_share_bps` is stored; there
   is no payout job.
 - **`motivational-images`** is still entirely fitness-specific and only makes

--- a/functions/admin-api/index.js
+++ b/functions/admin-api/index.js
@@ -127,6 +127,172 @@ async function updateUser(req, res, phone) {
   res.json(data);
 }
 
+// ---------------------------------------------------------------------------
+// Creators
+//
+// Approval is a platform action: protect_creator_platform_fields() silently
+// restores status, revenue_share_bps and the payout columns on any write that
+// carries an end-user JWT. These handlers run on the service role, where
+// auth.uid() is null and the trigger stands aside — which is exactly why they
+// live behind requireAdmin() in a Cloud Function and not in the browser.
+// ---------------------------------------------------------------------------
+
+const CREATOR_STATUSES = ['pending', 'approved', 'suspended'];
+const CREATOR_COLUMNS =
+  'id, created_at, updated_at, user_id, user_email, display_name, slug, bio, avatar_url, website_url, social_links, status, revenue_share_bps, payout_provider, payout_account_id';
+
+async function attachCoachCounts(creators) {
+  if (!creators || creators.length === 0) return creators || [];
+  const ids = creators.map((c) => c.id);
+  const { data, error } = await supabaseAdmin
+    .from('coach_profiles')
+    .select('id, creator_id, listing_status')
+    .in('creator_id', ids);
+
+  if (error) {
+    console.error('Error counting coaches for creators:', error);
+    return creators.map((c) => ({ ...c, coach_counts: null }));
+  }
+
+  const counts = new Map();
+  for (const coach of data || []) {
+    const bucket = counts.get(coach.creator_id) || { total: 0, listed: 0, in_review: 0 };
+    bucket.total += 1;
+    if (coach.listing_status === 'listed') bucket.listed += 1;
+    if (coach.listing_status === 'in_review') bucket.in_review += 1;
+    counts.set(coach.creator_id, bucket);
+  }
+
+  return creators.map((c) => ({
+    ...c,
+    coach_counts: counts.get(c.id) || { total: 0, listed: 0, in_review: 0 },
+  }));
+}
+
+async function listCreators(req, res) {
+  const { page = '1', pageSize = '50', search = '', status = '' } = req.query;
+  const pageNum = Math.max(parseInt(page, 10) || 1, 1);
+  const sizeNum = Math.min(Math.max(parseInt(pageSize, 10) || 50, 1), 200);
+  const from = (pageNum - 1) * sizeNum;
+  const to = from + sizeNum - 1;
+
+  let query = supabaseAdmin
+    .from('creator_profiles')
+    .select(CREATOR_COLUMNS, { count: 'exact' })
+    // Pending applications are the queue this page exists to work through.
+    .order('status', { ascending: true })
+    .order('created_at', { ascending: false })
+    .range(from, to);
+
+  if (status) {
+    if (!CREATOR_STATUSES.includes(status)) {
+      res.status(400).json({ error: `Unknown status "${status}"` });
+      return;
+    }
+    query = query.eq('status', status);
+  }
+
+  if (search) {
+    const escaped = search.replace(/[%,()]/g, '');
+    query = query.or(
+      `display_name.ilike.%${escaped}%,slug.ilike.%${escaped}%,user_email.ilike.%${escaped}%`
+    );
+  }
+
+  const { data, error, count } = await query;
+  if (error) {
+    console.error('Error listing creators:', error);
+    res.status(500).json({ error: 'Failed to list creators' });
+    return;
+  }
+
+  const creators = await attachCoachCounts(data || []);
+  res.json({ creators, total: count || 0, page: pageNum, pageSize: sizeNum });
+}
+
+async function getCreatorCoaches(req, res, creatorId) {
+  const { data, error } = await supabaseAdmin
+    .from('coach_profiles')
+    .select('id, name, handle, tagline, discipline, category_slug, listing_status, active, created_at')
+    .eq('creator_id', creatorId)
+    .order('created_at', { ascending: false });
+
+  if (error) {
+    console.error('Error loading creator coaches:', error);
+    res.status(500).json({ error: 'Failed to load coaches' });
+    return;
+  }
+  res.json({ coaches: data || [] });
+}
+
+async function updateCreator(req, res, creatorId) {
+  const payload = {};
+
+  if ('status' in req.body) {
+    if (!CREATOR_STATUSES.includes(req.body.status)) {
+      res.status(400).json({ error: `status must be one of ${CREATOR_STATUSES.join(', ')}` });
+      return;
+    }
+    payload.status = req.body.status;
+  }
+
+  if ('revenue_share_bps' in req.body) {
+    const bps = Number(req.body.revenue_share_bps);
+    if (!Number.isInteger(bps) || bps < 0 || bps > 10000) {
+      res.status(400).json({ error: 'revenue_share_bps must be an integer between 0 and 10000' });
+      return;
+    }
+    payload.revenue_share_bps = bps;
+  }
+
+  for (const key of ['payout_provider', 'payout_account_id']) {
+    if (key in req.body) payload[key] = req.body[key] || null;
+  }
+
+  if (Object.keys(payload).length === 0) {
+    res.status(400).json({ error: 'No valid fields to update' });
+    return;
+  }
+
+  const { data: creator, error } = await supabaseAdmin
+    .from('creator_profiles')
+    .update(payload)
+    .eq('id', creatorId)
+    .select(CREATOR_COLUMNS)
+    .single();
+
+  if (error || !creator) {
+    console.error('Error updating creator:', error);
+    res.status(error ? 500 : 404).json({ error: error ? 'Failed to update creator' : 'Creator not found' });
+    return;
+  }
+
+  // Approval is what the creator was waiting on, so anything they already
+  // submitted for review goes live with it. Suspension is the mirror image.
+  let coachesChanged = [];
+  if (payload.status === 'approved') {
+    const { data, error: listError } = await supabaseAdmin
+      .from('coach_profiles')
+      .update({ listing_status: 'listed', public: true })
+      .eq('creator_id', creatorId)
+      .eq('listing_status', 'in_review')
+      .select('id, name, listing_status');
+    if (listError) console.error('Error listing queued coaches:', listError);
+    coachesChanged = data || [];
+  } else if (payload.status === 'suspended') {
+    const { data, error: unlistError } = await supabaseAdmin
+      .from('coach_profiles')
+      .update({ listing_status: 'unlisted', public: false })
+      .eq('creator_id', creatorId)
+      .eq('listing_status', 'listed')
+      .select('id, name, listing_status');
+    if (unlistError) console.error('Error unlisting coaches:', unlistError);
+    coachesChanged = data || [];
+  }
+
+  res.json({ ...creator, coaches_changed: coachesChanged });
+}
+
 async function getChat(req, res, phone) {
   try {
     const file = storage.bucket(conversationBucketName).file(`${phone}/conversation.json`);
@@ -158,6 +324,24 @@ functions.http('adminApi', (req, res) => {
       if (method === 'GET' && path === '/users') {
         await listUsers(req, res);
         return;
+      }
+
+      if (method === 'GET' && path === '/creators') {
+        await listCreators(req, res);
+        return;
+      }
+
+      if (path.startsWith('/creators/')) {
+        const rest = path.slice('/creators/'.length);
+        const [creatorId, sub] = rest.split('/');
+        if (method === 'PATCH' && !sub) {
+          await updateCreator(req, res, creatorId);
+          return;
+        }
+        if (method === 'GET' && sub === 'coaches') {
+          await getCreatorCoaches(req, res, creatorId);
+          return;
+        }
       }
 
       if (path.startsWith('/users/')) {

--- a/mobile/e2e/creator-probe.mjs
+++ b/mobile/e2e/creator-probe.mjs
@@ -1,0 +1,312 @@
+/**
+ * The creator onboarding and publishing path, end to end, through PostgREST as
+ * a real authenticated user — so RLS, protect_creator_platform_fields() and
+ * enforce_coach_listing_rules() are all genuinely in play.
+ *
+ * The shape of the run mirrors the acceptance criteria on the issue:
+ *   a brand-new account creates a creator profile, builds a coach, and fails
+ *   to list it; the platform approves them; the coach then lists and shows up
+ *   in get_coach_roster(). Nothing the creator submits moves status or
+ *   revenue_share_bps.
+ *
+ * Approval is done on the service-role client, which is exactly what the
+ * admin-api Cloud Function does behind requireAdmin() — the trigger stands
+ * aside only when auth.uid() is null.
+ */
+import { createClient } from '@supabase/supabase-js';
+import fs from 'node:fs';
+
+const env = Object.fromEntries(
+  fs.readFileSync(process.env.ENV_FILE, 'utf8')
+    .split('\n').filter(Boolean)
+    .map((line) => {
+      const i = line.indexOf('=');
+      return [line.slice(0, i), line.slice(i + 1).replace(/^"|"$/g, '')];
+    })
+);
+
+const URL = env.API_URL;
+const ANON = env.ANON_KEY;
+const SERVICE = env.SERVICE_ROLE_KEY;
+
+const admin = createClient(URL, SERVICE, { auth: { persistSession: false } });
+const anon = createClient(URL, ANON, { auth: { persistSession: false } });
+
+let pass = 0, fail = 0;
+function check(name, ok, detail = '') {
+  if (ok) { pass++; console.log(`  ok    ${name}`); }
+  else { fail++; console.log(`  FAIL  ${name}${detail ? ` — ${detail}` : ''}`); }
+}
+function section(t) { console.log(`\n### ${t}`); }
+
+const stamp = Date.now().toString(36);
+const PASSWORD = 'creator-probe-123';
+
+async function makeUser(prefix) {
+  const email = `${prefix}${stamp}@example.com`;
+  const { data, error } = await admin.auth.admin.createUser({
+    email, password: PASSWORD, email_confirm: true,
+  });
+  if (error) throw new Error(`createUser: ${error.message}`);
+  const client = createClient(URL, ANON, { auth: { persistSession: false } });
+  const { error: signInErr } = await client.auth.signInWithPassword({ email, password: PASSWORD });
+  if (signInErr) throw new Error(`signIn: ${signInErr.message}`);
+  return { email, id: data.user.id, client };
+}
+
+const creatorUser = await makeUser('creator');
+const otherUser = await makeUser('other');
+
+// ---------------------------------------------------------------------------
+section('A brand-new account creates a creator profile');
+// ---------------------------------------------------------------------------
+
+let creator;
+{
+  // The handle format is enforced in the database as well as in the form.
+  const { error: badSlug } = await creatorUser.client.from('creator_profiles').insert({
+    user_id: creatorUser.id, user_email: creatorUser.email,
+    display_name: 'Bad Slug', slug: 'Not A Slug',
+  });
+  check('malformed handle rejected', badSlug?.code === '23514',
+        `${badSlug?.code} ${badSlug?.message}`);
+  check('  → names the slug constraint, so the UI can explain it',
+        /creator_slug_format/.test(badSlug?.message || ''), badSlug?.message);
+
+  const slug = `probe-drummer-${stamp}`;
+
+  const { data: freeBefore } = await creatorUser.client.rpc('creator_slug_available', { p_slug: slug });
+  check('creator_slug_available: free handle', freeBefore === true, String(freeBefore));
+
+  // Everything platform-owned is sent deliberately here: none of it may stick.
+  const { data, error } = await creatorUser.client.from('creator_profiles').insert({
+    user_id: creatorUser.id,
+    user_email: creatorUser.email,
+    display_name: 'Probe Drummer',
+    slug,
+    bio: 'Fifteen years behind a kit.',
+    website_url: 'https://example.com',
+    social_links: { instagram: '@probedrummer' },
+    status: 'approved',
+    revenue_share_bps: 10000,
+    payout_provider: 'manual',
+    payout_account_id: 'acct_attacker',
+  }).select().single();
+
+  check('creator profile created', !error && !!data, error?.message);
+  creator = data;
+  check('  → status is pending, not what the client asked for', data?.status === 'pending', data?.status);
+  check('  → revenue_share_bps is the platform default', data?.revenue_share_bps === 7000, String(data?.revenue_share_bps));
+  check('  → payout columns ignored', data?.payout_provider === null && data?.payout_account_id === null,
+        `${data?.payout_provider} / ${data?.payout_account_id}`);
+  check('  → user_email taken from the session', data?.user_email === creatorUser.email, data?.user_email);
+
+  const { data: freeAfter } = await otherUser.client.rpc('creator_slug_available', { p_slug: slug });
+  check('creator_slug_available: taken handle, even though RLS hides the row',
+        freeAfter === false, String(freeAfter));
+
+  const { error: dupe } = await creatorUser.client.from('creator_profiles').insert({
+    user_id: creatorUser.id, user_email: creatorUser.email,
+    display_name: 'Second Profile', slug: `probe-second-${stamp}`,
+  });
+  check('one creator profile per account', dupe?.code === '23505', `${dupe?.code} ${dupe?.message}`);
+}
+
+// ---------------------------------------------------------------------------
+section('Pending creator builds a coach');
+// ---------------------------------------------------------------------------
+
+let coach;
+{
+  const { data, error } = await creatorUser.client.from('coach_profiles').insert({
+    user_id: creatorUser.id,
+    user_email: creatorUser.email,
+    creator_id: creator.id,
+    name: 'Pocket Probe',
+    handle: `pocket-probe-${stamp}`,
+    description: 'Groove and timekeeping.',
+    discipline: 'Drum kit',
+    category_slug: 'music',
+    tagline: 'Find the pocket.',
+    expertise: ['groove', 'timekeeping'],
+    starter_prompts: ['My fills always rush.'],
+    primary_response_style: 'wise_mentor',
+  }).select().single();
+
+  check('coach created with creator_id attached', !error && data?.creator_id === creator.id, error?.message);
+  coach = data;
+  check('  → starts as a draft', data?.listing_status === 'draft', data?.listing_status);
+
+  // The creator may build and preview: reading and editing their own draft works.
+  const { error: editErr } = await creatorUser.client.from('coach_profiles')
+    .update({ tagline: 'Find the pocket, keep the pocket.' }).eq('id', coach.id);
+  check('pending creator can still edit their draft', !editErr, editErr?.message);
+}
+
+// ---------------------------------------------------------------------------
+section('A coach cannot be credited to someone else’s creator profile');
+// ---------------------------------------------------------------------------
+{
+  const { data: victim } = await admin.from('creator_profiles').insert({
+    user_id: otherUser.id, user_email: otherUser.email,
+    display_name: 'Approved Stranger', slug: `probe-stranger-${stamp}`, status: 'approved',
+  }).select().single();
+
+  const { error } = await creatorUser.client.from('coach_profiles')
+    .update({ creator_id: victim.id }).eq('id', coach.id);
+  check('borrowing an approved creator_id is refused', error?.code === '42501',
+        `${error?.code} ${error?.message}`);
+
+  const { data: stillMine } = await creatorUser.client
+    .from('coach_profiles').select('creator_id').eq('id', coach.id).single();
+  check('  → attribution unchanged', stillMine?.creator_id === creator.id, stillMine?.creator_id);
+}
+
+// ---------------------------------------------------------------------------
+section('Publishing fails while the creator is under review');
+// ---------------------------------------------------------------------------
+{
+  // Step one of the publish control: submitting for review always works.
+  const { error: reviewErr } = await creatorUser.client.from('coach_profiles')
+    .update({ listing_status: 'in_review' }).eq('id', coach.id);
+  check('draft → in_review is allowed', !reviewErr, reviewErr?.message);
+
+  // Step two is not.
+  const { error } = await creatorUser.client.from('coach_profiles')
+    .update({ listing_status: 'listed', public: true }).eq('id', coach.id);
+  check('in_review → listed is refused', !!error, 'no error raised');
+  check('  → as insufficient_privilege, which the web app renders as ' +
+        '“your creator account is still under review”',
+        error?.code === '42501', `${error?.code} ${error?.message}`);
+
+  const { data: after } = await creatorUser.client
+    .from('coach_profiles').select('listing_status').eq('id', coach.id).single();
+  check('  → the coach stays queued at in_review', after?.listing_status === 'in_review', after?.listing_status);
+
+  const { data: roster } = await anon.rpc('get_coach_roster', {
+    p_category: null, p_search: null, p_limit: 100, p_offset: 0,
+  });
+  check('  → and is absent from get_coach_roster()',
+        !(roster || []).some((c) => c.id === coach.id), 'found on the roster');
+}
+
+// ---------------------------------------------------------------------------
+section('The creator cannot approve themselves');
+// ---------------------------------------------------------------------------
+{
+  const { error } = await creatorUser.client.from('creator_profiles')
+    .update({ status: 'approved', revenue_share_bps: 10000, payout_account_id: 'acct_attacker' })
+    .eq('id', creator.id);
+  check('self-approval write is accepted but neutered', !error, error?.message);
+
+  const { data } = await creatorUser.client
+    .from('creator_profiles').select('status, revenue_share_bps, payout_account_id')
+    .eq('id', creator.id).single();
+  check('  → status still pending', data?.status === 'pending', data?.status);
+  check('  → revenue_share_bps still 7000', data?.revenue_share_bps === 7000, String(data?.revenue_share_bps));
+  check('  → payout account still empty', data?.payout_account_id === null, data?.payout_account_id);
+
+  // Profile edits the creator does own still land.
+  const { error: bioErr } = await creatorUser.client.from('creator_profiles')
+    .update({ bio: 'Fifteen years behind a kit, five of them teaching.' }).eq('id', creator.id);
+  check('  → but their own fields still save', !bioErr, bioErr?.message);
+}
+
+// ---------------------------------------------------------------------------
+section('An admin approves them (service role, as admin-api does)');
+// ---------------------------------------------------------------------------
+{
+  const { data, error } = await admin.from('creator_profiles')
+    .update({ status: 'approved' }).eq('id', creator.id).select().single();
+  check('approval lands on the service role', !error && data?.status === 'approved',
+        error?.message || data?.status);
+  creator = data;
+
+  // admin-api promotes whatever the creator already submitted for review.
+  const { data: promoted, error: promoteErr } = await admin.from('coach_profiles')
+    .update({ listing_status: 'listed', public: true })
+    .eq('creator_id', creator.id).eq('listing_status', 'in_review')
+    .select('id, listing_status');
+  check('queued coaches are published with the approval',
+        !promoteErr && promoted?.length === 1 && promoted[0].id === coach.id,
+        promoteErr?.message || JSON.stringify(promoted));
+
+  const { data: roster } = await anon.rpc('get_coach_roster', {
+    p_category: null, p_search: null, p_limit: 100, p_offset: 0,
+  });
+  const listed = (roster || []).find((c) => c.id === coach.id);
+  check('the coach appears in get_coach_roster()', !!listed, 'not on the roster');
+  check('  → credited to the creator', listed?.creator_name === 'Probe Drummer', listed?.creator_name);
+  check('  → with their handle', listed?.creator_slug === creator.slug, listed?.creator_slug);
+  check('  → and its own domain fields', listed?.discipline === 'Drum kit' && listed?.category_slug === 'music',
+        `${listed?.discipline} / ${listed?.category_slug}`);
+}
+
+// ---------------------------------------------------------------------------
+section('An approved creator can now publish from the app');
+// ---------------------------------------------------------------------------
+let secondCoach;
+{
+  const { data } = await creatorUser.client.from('coach_profiles').insert({
+    user_id: creatorUser.id, user_email: creatorUser.email, creator_id: creator.id,
+    name: 'Second Probe', handle: `second-probe-${stamp}`,
+    discipline: 'Snare rudiments', category_slug: 'music',
+    primary_response_style: 'cheerleader',
+  }).select().single();
+  secondCoach = data;
+
+  const { error: reviewErr } = await creatorUser.client.from('coach_profiles')
+    .update({ listing_status: 'in_review' }).eq('id', secondCoach.id);
+  check('draft → in_review', !reviewErr, reviewErr?.message);
+
+  const { error: listErr } = await creatorUser.client.from('coach_profiles')
+    .update({ listing_status: 'listed', public: true }).eq('id', secondCoach.id);
+  check('in_review → listed now succeeds as the creator themselves', !listErr, listErr?.message);
+
+  const { data: roster } = await anon.rpc('get_coach_roster', {
+    p_category: null, p_search: null, p_limit: 100, p_offset: 0,
+  });
+  check('  → and it reaches the roster', (roster || []).some((c) => c.id === secondCoach.id), 'not on the roster');
+
+  // Unlisting is the creator's own to do.
+  const { error: unlistErr } = await creatorUser.client.from('coach_profiles')
+    .update({ listing_status: 'unlisted', public: false }).eq('id', secondCoach.id);
+  check('the creator can take it back off the roster', !unlistErr, unlistErr?.message);
+}
+
+// ---------------------------------------------------------------------------
+section('Suspension pulls the listings');
+// ---------------------------------------------------------------------------
+{
+  await admin.from('creator_profiles').update({ status: 'suspended' }).eq('id', creator.id);
+  const { data: pulled } = await admin.from('coach_profiles')
+    .update({ listing_status: 'unlisted', public: false })
+    .eq('creator_id', creator.id).eq('listing_status', 'listed')
+    .select('id');
+  check('listed coaches are unlisted with the suspension', pulled?.length === 1, JSON.stringify(pulled));
+
+  const { data: roster } = await anon.rpc('get_coach_roster', {
+    p_category: null, p_search: null, p_limit: 100, p_offset: 0,
+  });
+  check('  → nothing of theirs is left on the roster',
+        !(roster || []).some((c) => c.id === coach.id || c.id === secondCoach.id), 'still listed');
+
+  const { error } = await creatorUser.client.from('coach_profiles')
+    .update({ listing_status: 'listed' }).eq('id', coach.id);
+  check('  → and a suspended creator cannot re-list', error?.code === '42501',
+        `${error?.code} ${error?.message}`);
+}
+
+// ---------------------------------------------------------------------------
+section('Cleanup');
+// ---------------------------------------------------------------------------
+{
+  await admin.from('coach_profiles').delete().in('id', [coach.id, secondCoach.id]);
+  await admin.from('creator_profiles').delete().in('user_id', [creatorUser.id, otherUser.id]);
+  await admin.auth.admin.deleteUser(creatorUser.id);
+  await admin.auth.admin.deleteUser(otherUser.id);
+  check('probe rows removed', true);
+}
+
+console.log(`\n${pass} passed, ${fail} failed`);
+process.exit(fail === 0 ? 0 : 1);

--- a/supabase/migrations/20260811120000_creator_self_signup.sql
+++ b/supabase/migrations/20260811120000_creator_self_signup.sql
@@ -1,0 +1,158 @@
+/*
+  # Creator self-signup guards
+
+  Becoming a creator used to be a manual INSERT run by the platform, so the
+  only guard on `creator_profiles` was `protect_creator_platform_fields()`,
+  which fires on UPDATE. Now that an end user can create their own row from the
+  web app, INSERT is a write path an untrusted client controls — and today it
+  can set `status = 'approved'` and `revenue_share_bps` on the way in.
+
+    1. protect_creator_platform_fields() also guards INSERT
+    2. one creator profile per account
+    3. creator_slug_available() so the client can pre-check a handle that RLS
+       would otherwise hide
+    4. enforce_coach_listing_rules() also refuses a creator_id you do not own
+*/
+
+-- ---------------------------------------------------------------------------
+-- 1. Platform fields are platform-owned on INSERT as well as UPDATE
+-- ---------------------------------------------------------------------------
+
+CREATE OR REPLACE FUNCTION public.protect_creator_platform_fields()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+BEGIN
+  -- No end user on the request (migrations, service-role writes) => trusted.
+  -- Approval, payout terms and the revenue split are all set through this path.
+  IF auth.uid() IS NULL THEN
+    RETURN NEW;
+  END IF;
+
+  IF TG_OP = 'INSERT' THEN
+    -- A creator signs themselves up as themselves, pending review, on the
+    -- standard split. Anything the client sent for these columns is discarded
+    -- rather than rejected, so the form never has to know they exist.
+    NEW.user_id           := auth.uid();
+    NEW.user_email        := COALESCE(NULLIF(auth.jwt() ->> 'email', ''), NEW.user_email);
+    NEW.status            := 'pending';
+    NEW.revenue_share_bps := 7000;  -- keep in sync with the column default
+    NEW.payout_provider   := NULL;
+    NEW.payout_account_id := NULL;
+    RETURN NEW;
+  END IF;
+
+  NEW.status            := OLD.status;
+  NEW.revenue_share_bps := OLD.revenue_share_bps;
+  NEW.payout_provider   := OLD.payout_provider;
+  NEW.payout_account_id := OLD.payout_account_id;
+  NEW.user_email        := OLD.user_email;
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS protect_creator_platform_fields_trigger ON public.creator_profiles;
+CREATE TRIGGER protect_creator_platform_fields_trigger
+    BEFORE INSERT OR UPDATE ON public.creator_profiles
+    FOR EACH ROW EXECUTE PROCEDURE public.protect_creator_platform_fields();
+
+COMMENT ON FUNCTION public.protect_creator_platform_fields()
+    IS 'Approval state, payout terms and the revenue split belong to the platform, on every end-user write';
+
+-- ---------------------------------------------------------------------------
+-- 2. One creator profile per account
+-- ---------------------------------------------------------------------------
+
+CREATE UNIQUE INDEX IF NOT EXISTS creator_profiles_user_id_key
+    ON public.creator_profiles (user_id)
+    WHERE user_id IS NOT NULL;
+
+-- ---------------------------------------------------------------------------
+-- 3. Handle availability
+-- ---------------------------------------------------------------------------
+
+-- "Anyone can view approved creators" hides pending and suspended rows, so a
+-- client-side SELECT would report a taken handle as free and the insert would
+-- then fail on the unique constraint. This answers the narrow question without
+-- leaking the row.
+CREATE OR REPLACE FUNCTION public.creator_slug_available(p_slug text)
+RETURNS boolean
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+    SELECT p_slug ~ '^[a-z0-9][a-z0-9-]{1,38}[a-z0-9]$'
+       AND NOT EXISTS (
+             SELECT 1 FROM public.creator_profiles
+             WHERE slug = p_slug
+               AND (user_id IS NULL OR user_id <> auth.uid())
+           );
+$$;
+
+COMMENT ON FUNCTION public.creator_slug_available(text)
+    IS 'True when the handle is well formed and not already held by another creator';
+
+GRANT EXECUTE ON FUNCTION public.creator_slug_available(text) TO authenticated, service_role;
+
+-- ---------------------------------------------------------------------------
+-- 4. A signed-out browse can see the creator behind a coach
+-- ---------------------------------------------------------------------------
+
+-- "Anyone can view approved creators" was written with anon in mind, but anon
+-- never got a table grant, so the coach-detail embed
+-- (`creator_profiles ( display_name, slug, avatar_url )`) fails outright for a
+-- signed-out reader. Grant the public face only — the payout account and the
+-- revenue split are nobody else's business.
+GRANT SELECT (
+    id, created_at, updated_at, display_name, slug, bio,
+    avatar_url, website_url, social_links, status
+) ON public.creator_profiles TO anon;
+
+-- ---------------------------------------------------------------------------
+-- 5. A coach may only be attributed to a creator profile its owner holds
+-- ---------------------------------------------------------------------------
+
+-- The listing check alone asked "is NEW.creator_id an approved creator?", not
+-- "is it yours". The RLS WITH CHECK does ask, but the legacy phone-claim UPDATE
+-- policy is permissive and ORs with it, so the ownership half has to live in
+-- the trigger too.
+CREATE OR REPLACE FUNCTION public.enforce_coach_listing_rules()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+BEGIN
+  -- No end user on the request (migrations, service-role writes) => trusted.
+  IF auth.uid() IS NULL THEN
+    RETURN NEW;
+  END IF;
+
+  IF NEW.creator_id IS NOT NULL
+     AND (TG_OP = 'INSERT' OR NEW.creator_id IS DISTINCT FROM OLD.creator_id) THEN
+    IF NOT EXISTS (
+      SELECT 1 FROM public.creator_profiles cr
+      WHERE cr.id = NEW.creator_id AND cr.user_id = auth.uid()
+    ) THEN
+      RAISE EXCEPTION 'Coach % cannot be credited to a creator profile you do not own', NEW.id
+        USING ERRCODE = 'insufficient_privilege';
+    END IF;
+  END IF;
+
+  IF NEW.listing_status = 'listed'
+     AND (TG_OP = 'INSERT' OR OLD.listing_status IS DISTINCT FROM 'listed') THEN
+    IF NOT EXISTS (
+      SELECT 1 FROM public.creator_profiles cr
+      WHERE cr.id = NEW.creator_id AND cr.status = 'approved'
+    ) THEN
+      RAISE EXCEPTION 'Coach % cannot be listed: it has no approved creator', NEW.id
+        USING ERRCODE = 'insufficient_privilege';
+    END IF;
+  END IF;
+
+  RETURN NEW;
+END;
+$$;

--- a/webapp/src/App.jsx
+++ b/webapp/src/App.jsx
@@ -24,6 +24,7 @@ import CoachDashboard from './components/MyCoaches/CoachDashboard';
 import CoachContentManager from './components/MyCoaches/CoachContentManager';
 import CoachEdit from './components/MyCoaches/CoachEdit';
 import CoachAvatarEdit from './components/MyCoaches/CoachAvatarEdit';
+import CreatorProfilePage from './components/Creator/CreatorProfilePage';
 import AdminDashboard from './components/AdminDashboard';
 import { AdminProtectedRoute } from './components/AdminProtectedRoute';
 
@@ -114,6 +115,7 @@ export function App() {
       <Route element={<ProtectedRoute session={session}><AuthenticatedLayout session={session} /></ProtectedRoute>}>
         <Route path="/settings" element={<SettingsPage />} />
         <Route path="/billing" element={<BillingPage />} />
+        <Route path="/creator" element={<CreatorProfilePage />} />
         <Route path="/my-coaches" element={<CoachDashboard />} />
         <Route path="/my-coaches/:coachId/content" element={<CoachContentManager />} />
         <Route path="/my-coaches/:coachId/edit" element={<CoachEdit />} />

--- a/webapp/src/components/AdminDashboard.jsx
+++ b/webapp/src/components/AdminDashboard.jsx
@@ -50,8 +50,240 @@ function Table({ columns, rows, onRowClick }) {
   );
 }
 
+const CREATOR_STATUS_STYLE = {
+  pending: 'bg-yellow-100 text-yellow-800',
+  approved: 'bg-green-100 text-green-800',
+  suspended: 'bg-red-100 text-red-800',
+};
+
+/**
+ * Creator approval. The status, revenue share and payout columns are all
+ * restored by a database trigger on any write that carries an end-user JWT, so
+ * every action here goes through the admin Cloud Function, which holds the
+ * service role key server-side. Nothing on this page could work from the
+ * browser's Supabase client, and that is deliberate.
+ */
+function CreatorsPanel({ callAdmin }) {
+  const [creators, setCreators] = useState([]);
+  const [loading, setLoading] = useState(false);
+  const [search, setSearch] = useState('');
+  const [statusFilter, setStatusFilter] = useState('pending');
+  const [busyId, setBusyId] = useState(null);
+  const [expanded, setExpanded] = useState(null);
+  const [coaches, setCoaches] = useState([]);
+  const [shareDraft, setShareDraft] = useState({});
+
+  async function loadCreators() {
+    setLoading(true);
+    try {
+      const params = new URLSearchParams({ pageSize: '100' });
+      if (statusFilter) params.set('status', statusFilter);
+      if (search) params.set('search', search);
+      const data = await callAdmin(`/creators?${params.toString()}`);
+      setCreators(data.creators || []);
+    } catch (e) {
+      console.error(e);
+      toast.error('Failed to load creators');
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  useEffect(() => {
+    loadCreators();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [statusFilter]);
+
+  async function openCreator(creator) {
+    if (expanded === creator.id) {
+      setExpanded(null);
+      return;
+    }
+    setExpanded(creator.id);
+    setCoaches([]);
+    try {
+      const data = await callAdmin(`/creators/${creator.id}/coaches`);
+      setCoaches(data.coaches || []);
+    } catch (e) {
+      console.error(e);
+      toast.error('Failed to load this creator’s coaches');
+    }
+  }
+
+  async function patchCreator(creator, body, successMessage) {
+    setBusyId(creator.id);
+    try {
+      const updated = await callAdmin(`/creators/${creator.id}`, {
+        method: 'PATCH',
+        body: JSON.stringify(body),
+      });
+      const changed = updated.coaches_changed || [];
+      toast.success(
+        changed.length > 0
+          ? `${successMessage} ${changed.length} coach${changed.length === 1 ? '' : 'es'} ${
+              updated.status === 'approved' ? 'published to the roster' : 'taken off the roster'
+            }.`
+          : successMessage
+      );
+      await loadCreators();
+      if (expanded === creator.id) {
+        const data = await callAdmin(`/creators/${creator.id}/coaches`);
+        setCoaches(data.coaches || []);
+      }
+    } catch (e) {
+      console.error(e);
+      toast.error('Update failed');
+    } finally {
+      setBusyId(null);
+    }
+  }
+
+  return (
+    <div className="space-y-4">
+      <div className="flex flex-wrap items-center gap-2">
+        <select
+          value={statusFilter}
+          onChange={(e) => setStatusFilter(e.target.value)}
+          className="border px-3 py-2 rounded"
+        >
+          <option value="pending">Pending review</option>
+          <option value="approved">Approved</option>
+          <option value="suspended">Suspended</option>
+          <option value="">All</option>
+        </select>
+        <input
+          value={search}
+          onChange={(e) => setSearch(e.target.value)}
+          onKeyDown={(e) => { if (e.key === 'Enter') loadCreators(); }}
+          placeholder="Search name, handle, or email"
+          className="border px-3 py-2 rounded w-72"
+        />
+        <button onClick={loadCreators} className="bg-blue-600 text-white px-4 py-2 rounded">Search</button>
+      </div>
+
+      {loading ? (
+        <div className="p-4 border rounded">Loading…</div>
+      ) : creators.length === 0 ? (
+        <div className="p-6 border rounded text-sm text-gray-500">
+          No creators {statusFilter ? `with status "${statusFilter}"` : ''}.
+        </div>
+      ) : (
+        <div className="space-y-3">
+          {creators.map((creator) => (
+            <div key={creator.id} className="border rounded">
+              <div className="p-4 flex flex-wrap items-center gap-3">
+                <div className="flex-1 min-w-[220px]">
+                  <div className="flex items-center gap-2">
+                    <span className="font-semibold">{creator.display_name}</span>
+                    <span className="text-sm text-gray-500">/creators/{creator.slug}</span>
+                    <span className={`px-2 py-0.5 rounded-full text-xs font-medium ${CREATOR_STATUS_STYLE[creator.status] || 'bg-gray-100 text-gray-700'}`}>
+                      {creator.status}
+                    </span>
+                  </div>
+                  <div className="text-sm text-gray-600">{creator.user_email}</div>
+                  {creator.coach_counts && (
+                    <div className="text-xs text-gray-500 mt-1">
+                      {creator.coach_counts.total} coach{creator.coach_counts.total === 1 ? '' : 'es'}
+                      {creator.coach_counts.in_review > 0 && ` · ${creator.coach_counts.in_review} awaiting listing`}
+                      {creator.coach_counts.listed > 0 && ` · ${creator.coach_counts.listed} listed`}
+                    </div>
+                  )}
+                </div>
+
+                <div className="flex items-center gap-2">
+                  <label className="text-xs text-gray-500">Share %</label>
+                  <input
+                    type="number"
+                    min={0}
+                    max={100}
+                    value={shareDraft[creator.id] ?? Math.round(creator.revenue_share_bps / 100)}
+                    onChange={(e) => setShareDraft((p) => ({ ...p, [creator.id]: e.target.value }))}
+                    className="border px-2 py-1 rounded w-16"
+                  />
+                  <button
+                    disabled={busyId === creator.id}
+                    onClick={() => patchCreator(
+                      creator,
+                      { revenue_share_bps: Math.round(Number(shareDraft[creator.id] ?? creator.revenue_share_bps / 100) * 100) },
+                      'Revenue share updated.'
+                    )}
+                    className="px-3 py-1 border rounded text-sm disabled:opacity-50"
+                  >
+                    Save
+                  </button>
+                </div>
+
+                <div className="flex items-center gap-2">
+                  {creator.status !== 'approved' && (
+                    <button
+                      disabled={busyId === creator.id}
+                      onClick={() => patchCreator(creator, { status: 'approved' }, `${creator.display_name} approved.`)}
+                      className="bg-green-600 text-white px-4 py-2 rounded disabled:opacity-50"
+                    >
+                      Approve
+                    </button>
+                  )}
+                  {creator.status !== 'suspended' && (
+                    <button
+                      disabled={busyId === creator.id}
+                      onClick={() => patchCreator(creator, { status: 'suspended' }, `${creator.display_name} suspended.`)}
+                      className="bg-red-100 text-red-700 px-4 py-2 rounded disabled:opacity-50"
+                    >
+                      Suspend
+                    </button>
+                  )}
+                  <button onClick={() => openCreator(creator)} className="px-3 py-2 border rounded text-sm">
+                    {expanded === creator.id ? 'Hide' : 'Details'}
+                  </button>
+                </div>
+              </div>
+
+              {expanded === creator.id && (
+                <div className="border-t p-4 bg-gray-50 space-y-3 text-sm">
+                  {creator.bio && <p className="text-gray-700 whitespace-pre-line">{creator.bio}</p>}
+                  {creator.website_url && (
+                    <a href={creator.website_url} target="_blank" rel="noreferrer" className="text-blue-600 underline">
+                      {creator.website_url}
+                    </a>
+                  )}
+                  {creator.social_links && Object.keys(creator.social_links).length > 0 && (
+                    <div className="flex flex-wrap gap-3 text-gray-600">
+                      {Object.entries(creator.social_links).map(([key, value]) => (
+                        <span key={key}><span className="capitalize text-gray-500">{key}:</span> {value}</span>
+                      ))}
+                    </div>
+                  )}
+                  <div>
+                    <h4 className="font-medium mb-1">Coaches</h4>
+                    {coaches.length === 0 ? (
+                      <div className="text-gray-500">None yet.</div>
+                    ) : (
+                      <ul className="divide-y bg-white border rounded">
+                        {coaches.map((coach) => (
+                          <li key={coach.id} className="px-3 py-2 flex justify-between">
+                            <span>
+                              {coach.name} <span className="text-gray-500">@{coach.handle}</span>
+                              {coach.discipline && <span className="text-gray-400"> — {coach.discipline}</span>}
+                            </span>
+                            <span className="text-gray-600 capitalize">{(coach.listing_status || 'draft').replace('_', ' ')}</span>
+                          </li>
+                        ))}
+                      </ul>
+                    )}
+                  </div>
+                </div>
+              )}
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
 export default function AdminDashboard() {
   const token = useAdminToken();
+  const [tab, setTab] = useState('users');
   const [loading, setLoading] = useState(false);
   const [search, setSearch] = useState('');
   const [page, setPage] = useState(1);
@@ -155,6 +387,25 @@ export default function AdminDashboard() {
   return (
     <div className="p-4 space-y-4">
       <h1 className="text-2xl font-semibold">Admin Dashboard</h1>
+
+      <div className="flex gap-2 border-b">
+        {[['users', 'Users'], ['creators', 'Creators']].map(([key, label]) => (
+          <button
+            key={key}
+            onClick={() => setTab(key)}
+            className={`px-4 py-2 -mb-px border-b-2 font-medium ${
+              tab === key ? 'border-blue-600 text-blue-700' : 'border-transparent text-gray-500 hover:text-gray-700'
+            }`}
+          >
+            {label}
+          </button>
+        ))}
+      </div>
+
+      {tab === 'creators' ? (
+        token ? <CreatorsPanel callAdmin={callAdmin} /> : <div className="p-4">Loading…</div>
+      ) : (
+      <>
       <div className="flex items-center gap-2">
         <input
           value={search}
@@ -236,6 +487,8 @@ export default function AdminDashboard() {
             </div>
           </div>
         </div>
+      )}
+      </>
       )}
     </div>
   );

--- a/webapp/src/components/Creator/CreatorProfilePage.jsx
+++ b/webapp/src/components/Creator/CreatorProfilePage.jsx
@@ -1,0 +1,308 @@
+import React, { useEffect, useMemo, useState } from 'react';
+import { Link } from 'react-router-dom';
+import { toast } from 'react-hot-toast';
+import { supabase } from '../../main';
+import {
+  CREATOR_SLUG_RULE,
+  CREATOR_SOCIAL_PLATFORMS,
+  createCreatorProfile,
+  isCreatorSlugAvailable,
+  slugifyCreatorName,
+  updateCreatorProfile,
+  validateCreatorForm,
+  validateCreatorSlug,
+} from '../../utils/creators';
+import { useCreatorProfile } from '../../hooks/useCreatorProfile';
+import CreatorStatusBanner from './CreatorStatusBanner';
+
+const EMPTY_FORM = {
+  display_name: '',
+  slug: '',
+  bio: '',
+  avatar_url: '',
+  website_url: '',
+  social_links: {},
+};
+
+function formFromProfile(profile) {
+  if (!profile) return { ...EMPTY_FORM };
+  return {
+    display_name: profile.display_name || '',
+    slug: profile.slug || '',
+    bio: profile.bio || '',
+    avatar_url: profile.avatar_url || '',
+    website_url: profile.website_url || '',
+    social_links: profile.social_links || {},
+  };
+}
+
+const Field = ({ label, hint, error, children }) => (
+  <div className="space-y-1">
+    <label className="block text-sm font-medium text-gray-700">{label}</label>
+    {children}
+    {error ? (
+      <p className="text-sm text-red-600">{error}</p>
+    ) : hint ? (
+      <p className="text-xs text-gray-500">{hint}</p>
+    ) : null}
+  </div>
+);
+
+const inputClass = (hasError) =>
+  `w-full px-3 py-2 border rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500 ${
+    hasError ? 'border-red-400' : 'border-gray-300'
+  }`;
+
+const CreatorProfilePage = () => {
+  const { creator, setCreator, loading } = useCreatorProfile();
+  const [form, setForm] = useState(EMPTY_FORM);
+  const [errors, setErrors] = useState({});
+  const [saving, setSaving] = useState(false);
+  const [slugTouched, setSlugTouched] = useState(false);
+  const [slugTaken, setSlugTaken] = useState(false);
+  const [coaches, setCoaches] = useState([]);
+
+  const isNew = !creator;
+
+  useEffect(() => {
+    if (creator) {
+      setForm(formFromProfile(creator));
+      setSlugTouched(true);
+    }
+  }, [creator]);
+
+  useEffect(() => {
+    if (!creator) return;
+    let cancelled = false;
+    supabase
+      .from('coach_profiles')
+      .select('id, name, handle, listing_status, active')
+      .eq('creator_id', creator.id)
+      .order('created_at', { ascending: false })
+      .then(({ data }) => { if (!cancelled) setCoaches(data || []); });
+    return () => { cancelled = true; };
+  }, [creator]);
+
+  // Handle availability is checked against a SECURITY DEFINER function, because
+  // RLS hides pending creators' rows and would report a taken handle as free.
+  const slug = form.slug;
+  useEffect(() => {
+    if (!slug || validateCreatorSlug(slug)) { setSlugTaken(false); return; }
+    let cancelled = false;
+    const timer = setTimeout(async () => {
+      const available = await isCreatorSlugAvailable(slug);
+      if (!cancelled) setSlugTaken(!available);
+    }, 350);
+    return () => { cancelled = true; clearTimeout(timer); };
+  }, [slug]);
+
+  const update = (field, value) => {
+    setForm((prev) => {
+      const next = { ...prev, [field]: value };
+      // Suggest a handle while the creator has not chosen one themselves.
+      if (field === 'display_name' && !slugTouched) {
+        next.slug = slugifyCreatorName(value);
+      }
+      return next;
+    });
+    setErrors((prev) => ({ ...prev, [field]: undefined }));
+  };
+
+  const updateSocial = (key, value) => {
+    setForm((prev) => ({ ...prev, social_links: { ...(prev.social_links || {}), [key]: value } }));
+  };
+
+  const slugError = useMemo(() => {
+    if (errors.slug) return errors.slug;
+    if (slugTaken) return `The handle "${form.slug}" is already taken. Try another.`;
+    return null;
+  }, [errors.slug, slugTaken, form.slug]);
+
+  const handleSubmit = async (event) => {
+    event.preventDefault();
+    const nextErrors = validateCreatorForm(form);
+    setErrors(nextErrors);
+    if (Object.keys(nextErrors).length > 0) return;
+    if (slugTaken) return;
+
+    setSaving(true);
+    try {
+      const saved = isNew
+        ? await createCreatorProfile(form)
+        : await updateCreatorProfile(creator.id, form);
+      setCreator(saved);
+      toast.success(isNew ? 'Creator profile created — we will review it shortly.' : 'Creator profile updated.');
+    } catch (error) {
+      console.error('Failed to save creator profile:', error);
+      const message = error.message || 'Failed to save creator profile.';
+      if (/handle/i.test(message)) setErrors((prev) => ({ ...prev, slug: message }));
+      toast.error(message);
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  if (loading) {
+    return (
+      <div className="p-8 flex items-center justify-center">
+        <div className="animate-spin rounded-full h-10 w-10 border-t-2 border-b-2 border-blue-600" />
+      </div>
+    );
+  }
+
+  return (
+    <div className="p-8 max-w-3xl mx-auto space-y-6">
+      <div>
+        <h1 className="text-3xl font-bold text-gray-900">
+          {isNew ? 'Become a creator' : 'Creator profile'}
+        </h1>
+        <p className="text-gray-600 mt-2">
+          {isNew
+            ? 'Creators publish coaches on the platform and get paid for them. Tell us who you are and we will review your account.'
+            : 'This is the profile audiences see next to every coach you publish.'}
+        </p>
+      </div>
+
+      <CreatorStatusBanner status={creator?.status || 'none'} />
+
+      <form onSubmit={handleSubmit} className="bg-white border border-gray-200 rounded-lg p-6 space-y-5">
+        <Field label="Display name" error={errors.display_name} hint="The name shown on your coaches.">
+          <input
+            className={inputClass(errors.display_name)}
+            value={form.display_name}
+            onChange={(e) => update('display_name', e.target.value)}
+            placeholder="Ada Rivers"
+            maxLength={80}
+          />
+        </Field>
+
+        <Field label="Handle" error={slugError} hint={CREATOR_SLUG_RULE}>
+          <div className="flex items-center">
+            <span className="px-3 py-2 border border-r-0 border-gray-300 rounded-l-lg bg-gray-50 text-gray-500 text-sm">
+              /creators/
+            </span>
+            <input
+              className={`${inputClass(!!slugError)} rounded-l-none`}
+              value={form.slug}
+              onChange={(e) => { setSlugTouched(true); update('slug', e.target.value.toLowerCase()); }}
+              placeholder="ada-rivers"
+              maxLength={40}
+            />
+          </div>
+        </Field>
+
+        <Field label="Bio" hint="A couple of sentences on what you teach and who you teach it to.">
+          <textarea
+            className={inputClass(false)}
+            rows={4}
+            value={form.bio}
+            onChange={(e) => update('bio', e.target.value)}
+            placeholder="I have taught drum kit for fifteen years…"
+            maxLength={1000}
+          />
+        </Field>
+
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-5">
+          <Field label="Avatar URL" error={errors.avatar_url} hint="A square image works best.">
+            <input
+              className={inputClass(errors.avatar_url)}
+              value={form.avatar_url}
+              onChange={(e) => update('avatar_url', e.target.value)}
+              placeholder="https://…"
+            />
+          </Field>
+          <Field label="Website" error={errors.website_url}>
+            <input
+              className={inputClass(errors.website_url)}
+              value={form.website_url}
+              onChange={(e) => update('website_url', e.target.value)}
+              placeholder="https://…"
+            />
+          </Field>
+        </div>
+
+        <div className="space-y-2">
+          <h2 className="text-sm font-medium text-gray-700">Social links</h2>
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
+            {CREATOR_SOCIAL_PLATFORMS.map((platform) => (
+              <div key={platform.key} className="flex items-center gap-2">
+                <span className="w-24 shrink-0 text-sm text-gray-500">{platform.label}</span>
+                <input
+                  className={inputClass(false)}
+                  value={form.social_links?.[platform.key] || ''}
+                  onChange={(e) => updateSocial(platform.key, e.target.value)}
+                  placeholder={platform.placeholder}
+                />
+              </div>
+            ))}
+          </div>
+        </div>
+
+        {form.avatar_url && (
+          <div className="flex items-center gap-3 pt-2">
+            <img
+              src={form.avatar_url}
+              alt=""
+              className="w-12 h-12 rounded-full object-cover border border-gray-200"
+              onError={(e) => { e.currentTarget.style.display = 'none'; }}
+            />
+            <span className="text-sm text-gray-500">Avatar preview</span>
+          </div>
+        )}
+
+        <div className="flex items-center gap-3 pt-2">
+          <button
+            type="submit"
+            disabled={saving}
+            className="bg-blue-600 text-white px-6 py-2 rounded-lg font-medium hover:bg-blue-700 disabled:opacity-50"
+          >
+            {saving ? 'Saving…' : isNew ? 'Create creator profile' : 'Save changes'}
+          </button>
+          {!isNew && (
+            <Link to="/my-coaches" className="text-sm text-gray-600 hover:text-gray-900">
+              My coaches →
+            </Link>
+          )}
+        </div>
+      </form>
+
+      {creator && (
+        <div className="bg-gray-50 border border-gray-200 rounded-lg p-6 space-y-3">
+          <h2 className="font-semibold text-gray-900">Platform terms</h2>
+          <p className="text-sm text-gray-600">
+            These are set by the platform, not by you. Nothing this form submits can change them.
+          </p>
+          <div className="grid grid-cols-2 gap-y-2 text-sm max-w-sm">
+            <span className="text-gray-500">Approval status</span>
+            <span className="font-medium capitalize">{creator.status}</span>
+            <span className="text-gray-500">Your revenue share</span>
+            <span className="font-medium">{(creator.revenue_share_bps / 100).toFixed(0)}%</span>
+            <span className="text-gray-500">Payouts</span>
+            <span className="font-medium">{creator.payout_provider || 'Not set up yet'}</span>
+          </div>
+        </div>
+      )}
+
+      {creator && coaches.length > 0 && (
+        <div className="bg-white border border-gray-200 rounded-lg p-6 space-y-3">
+          <h2 className="font-semibold text-gray-900">Coaches credited to you</h2>
+          <ul className="divide-y">
+            {coaches.map((coach) => (
+              <li key={coach.id} className="py-2 flex items-center justify-between text-sm">
+                <span>
+                  {coach.name} <span className="text-gray-500">@{coach.handle}</span>
+                </span>
+                <span className="text-gray-500 capitalize">{(coach.listing_status || 'draft').replace('_', ' ')}</span>
+              </li>
+            ))}
+          </ul>
+          <Link to="/my-coaches" className="text-sm text-blue-600 hover:underline">
+            Publish and manage them →
+          </Link>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default CreatorProfilePage;

--- a/webapp/src/components/Creator/CreatorStatusBanner.jsx
+++ b/webapp/src/components/Creator/CreatorStatusBanner.jsx
@@ -1,0 +1,56 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
+
+/**
+ * States approval honestly. A pending creator is not blocked from building —
+ * they are blocked from the roster, and the banner says exactly that.
+ */
+export const CREATOR_STATUS_COPY = {
+  none: {
+    tone: 'bg-blue-50 border-blue-200 text-blue-900',
+    icon: '✨',
+    title: 'You are not a creator yet',
+    body: 'Creator profiles are what let a coach be published to the roster. Setting one up takes a minute.',
+  },
+  pending: {
+    tone: 'bg-yellow-50 border-yellow-200 text-yellow-900',
+    icon: '⏳',
+    title: 'Your creator account is under review',
+    body: 'You can build, preview and chat with your coaches right now. Publishing to the public roster unlocks once we approve you — we will list anything you have submitted as soon as that happens.',
+  },
+  approved: {
+    tone: 'bg-green-50 border-green-200 text-green-900',
+    icon: '✅',
+    title: 'Approved creator',
+    body: 'You can publish your coaches to the public roster.',
+  },
+  suspended: {
+    tone: 'bg-red-50 border-red-200 text-red-900',
+    icon: '⛔',
+    title: 'Your creator account is suspended',
+    body: 'Your coaches are hidden from the roster and cannot be published. Get in touch and we will take another look.',
+  },
+};
+
+export const CreatorStatusBanner = ({ status, showLink = false, className = '' }) => {
+  const copy = CREATOR_STATUS_COPY[status] || CREATOR_STATUS_COPY.none;
+
+  return (
+    <div className={`border rounded-lg p-4 ${copy.tone} ${className}`}>
+      <div className="flex items-start gap-3">
+        <div className="text-xl leading-none" aria-hidden="true">{copy.icon}</div>
+        <div className="flex-1">
+          <h3 className="font-semibold">{copy.title}</h3>
+          <p className="text-sm mt-1 opacity-90">{copy.body}</p>
+          {showLink && (
+            <Link to="/creator" className="inline-block mt-2 text-sm font-medium underline">
+              {status && status !== 'none' ? 'Manage creator profile →' : 'Set up your creator profile →'}
+            </Link>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default CreatorStatusBanner;

--- a/webapp/src/components/MyCoaches/CoachDashboard.jsx
+++ b/webapp/src/components/MyCoaches/CoachDashboard.jsx
@@ -2,6 +2,14 @@ import React, { useState, useEffect } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
 import { supabase } from '../../main';
 import { toast } from 'react-hot-toast';
+import {
+  LISTING_LABELS,
+  listingBadgeClass,
+  publishCoach,
+  unlistCoach,
+} from '../../utils/creators';
+import { useCreatorProfile } from '../../hooks/useCreatorProfile';
+import CreatorStatusBanner from '../Creator/CreatorStatusBanner';
 
 // Chat Modal Component
 const CoachChatModal = ({ coach, isOpen, onClose }) => {
@@ -180,6 +188,8 @@ const CoachDashboard = () => {
   const [user, setUser] = useState(null);
   const [chatModalOpen, setChatModalOpen] = useState(false);
   const [selectedCoach, setSelectedCoach] = useState(null);
+  const [publishingId, setPublishingId] = useState(null);
+  const { creator, loading: creatorLoading } = useCreatorProfile();
   const navigate = useNavigate();
 
   useEffect(() => {
@@ -227,34 +237,57 @@ const CoachDashboard = () => {
     setSelectedCoach(null);
   };
 
-  const togglePublicStatus = async (coach) => {
+  const applyListingResult = (coach, result) => {
+    setCoaches(prevCoaches =>
+      prevCoaches.map(c =>
+        c.id === coach.id
+          ? {
+              ...c,
+              listing_status: result.listing_status,
+              creator_id: creator ? creator.id : c.creator_id,
+            }
+          : c
+      )
+    );
+  };
+
+  // draft → in_review → listed. Submitting for review always works; reaching
+  // the roster needs an approved creator, and the database is the one that
+  // decides. A refusal is reported as approval state, not as a Postgres error.
+  const handlePublish = async (coach) => {
+    if (!creator) {
+      toast.error('Set up your creator profile before publishing a coach.');
+      navigate('/creator');
+      return;
+    }
+    setPublishingId(coach.id);
     try {
-      const newPublicStatus = !coach.public;
-      
-      const { error } = await supabase
-        .from('coach_profiles')
-        .update({ public: newPublicStatus })
-        .eq('id', coach.id);
-
-      if (error) throw error;
-
-      // Update the local state
-      setCoaches(prevCoaches => 
-        prevCoaches.map(c => 
-          c.id === coach.id 
-            ? { ...c, public: newPublicStatus }
-            : c
-        )
-      );
-
-      toast.success(
-        newPublicStatus 
-          ? `${coach.name} is now public and visible to everyone!` 
-          : `${coach.name} is now private and only visible to you.`
-      );
+      const result = await publishCoach(coach, creator);
+      applyListingResult(coach, result);
+      if (result.listed) {
+        toast.success(result.message);
+      } else {
+        toast(result.message, { icon: '⏳', duration: 7000 });
+      }
     } catch (error) {
-      console.error('Error updating coach public status:', error);
-      toast.error('Failed to update coach visibility');
+      console.error('Error publishing coach:', error);
+      toast.error(error.message || 'Failed to publish this coach');
+    } finally {
+      setPublishingId(null);
+    }
+  };
+
+  const handleUnlist = async (coach) => {
+    setPublishingId(coach.id);
+    try {
+      const result = await unlistCoach(coach);
+      applyListingResult(coach, result);
+      toast.success(result.message);
+    } catch (error) {
+      console.error('Error unlisting coach:', error);
+      toast.error(error.message || 'Failed to unlist this coach');
+    } finally {
+      setPublishingId(null);
     }
   };
 
@@ -283,6 +316,14 @@ const CoachDashboard = () => {
           + Create New Coach
         </Link>
       </div>
+
+      {!creatorLoading && (creator?.status !== 'approved') && (
+        <CreatorStatusBanner
+          status={creator?.status || 'none'}
+          showLink
+          className="mb-8"
+        />
+      )}
 
       {coaches.length === 0 ? (
         // Empty state
@@ -317,12 +358,8 @@ const CoachDashboard = () => {
                   }`}>
                     {coach.active ? 'Active' : 'Inactive'}
                   </div>
-                  <div className={`px-2 py-1 rounded-full text-xs font-medium ${
-                    coach.public 
-                      ? 'bg-blue-100 text-blue-800' 
-                      : 'bg-orange-100 text-orange-800'
-                  }`}>
-                    {coach.public ? 'Public' : 'Private'}
+                  <div className={`px-2 py-1 rounded-full text-xs font-medium ${listingBadgeClass(coach.listing_status)}`}>
+                    {LISTING_LABELS[coach.listing_status] || 'Draft'}
                   </div>
                 </div>
               </div>
@@ -368,23 +405,41 @@ const CoachDashboard = () => {
                   </button>
                 </div>
                 <div className="grid grid-cols-2 gap-2">
-                  <button 
-                    onClick={() => togglePublicStatus(coach)}
-                    className={`px-3 py-2 rounded-lg text-sm font-medium transition-colors ${
-                      coach.public
-                        ? 'bg-orange-100 text-orange-700 hover:bg-orange-200'
-                        : 'bg-blue-100 text-blue-700 hover:bg-blue-200'
-                    }`}
-                  >
-                    {coach.public ? '🔒 Make Private' : '🌍 Publish'}
-                  </button>
-                  <button 
+                  {coach.listing_status === 'listed' ? (
+                    <button
+                      onClick={() => handleUnlist(coach)}
+                      disabled={publishingId === coach.id}
+                      className="bg-orange-100 text-orange-700 px-3 py-2 rounded-lg hover:bg-orange-200 text-sm font-medium disabled:opacity-50"
+                    >
+                      {publishingId === coach.id ? '…' : '🔒 Unlist'}
+                    </button>
+                  ) : (
+                    <button
+                      onClick={() => handlePublish(coach)}
+                      disabled={publishingId === coach.id || creator?.status === 'suspended'}
+                      className="bg-blue-100 text-blue-700 px-3 py-2 rounded-lg hover:bg-blue-200 text-sm font-medium disabled:opacity-50"
+                    >
+                      {publishingId === coach.id
+                        ? '…'
+                        : coach.listing_status === 'in_review'
+                          ? '🌍 Retry publish'
+                          : '🌍 Publish'}
+                    </button>
+                  )}
+                  <button
                     onClick={() => navigate(`/my-coaches/${coach.id}/content`)}
                     className="bg-purple-100 text-purple-700 px-3 py-2 rounded-lg hover:bg-purple-200 text-sm font-medium"
                   >
                     📁 Content
                   </button>
                 </div>
+                {coach.listing_status === 'in_review' && (
+                  <p className="text-xs text-yellow-700">
+                    {creator?.status === 'approved'
+                      ? 'Submitted — publish again to put it on the roster.'
+                      : 'Submitted. It goes live as soon as your creator account is approved.'}
+                  </p>
+                )}
               </div>
             </div>
           ))}

--- a/webapp/src/components/layout/AuthenticatedLayout.jsx
+++ b/webapp/src/components/layout/AuthenticatedLayout.jsx
@@ -31,6 +31,7 @@ export const AuthenticatedLayout = ({ session }) => {
           <li><Link to="/">Home (Main App)</Link></li>
           <li><Link to="/coach-builder">Coach Builder</Link></li>
           <li><Link to="/my-coaches">My Coaches</Link></li>
+          <li><Link to="/creator">Creator</Link></li>
           <li><Link to="/settings">Settings</Link></li>
           <li><Link to="/billing">Billing</Link></li>
           <li><Link to="/coaches">Coaches</Link></li>

--- a/webapp/src/contexts/CoachBuilderContext.jsx
+++ b/webapp/src/contexts/CoachBuilderContext.jsx
@@ -1,6 +1,7 @@
 import React, { createContext, useContext, useState, useEffect } from 'react';
 import { supabase } from '../main';
 import { toast } from 'react-hot-toast';
+import { fetchMyCreatorProfile } from '../utils/creators';
 
 const CoachBuilderContext = createContext();
 
@@ -345,9 +346,14 @@ export const CoachBuilderProvider = ({ children }) => {
 
       // Insert minimal coach profile as draft if none exists yet
       if (!previewCoachId) {
+        // Credit the coach to the builder's creator profile from the start, so
+        // publishing later is a listing_status change and nothing else.
+        const creator = await fetchMyCreatorProfile();
+
         const dbData = {
           user_id: user.id,
           user_email: user.email,
+          creator_id: creator?.id || null,
           name: coachData.name || 'Sample Coach',
           handle: coachData.handle || `coach-${Math.random().toString(36).slice(2,8)}`,
           description: coachData.description || null,
@@ -477,10 +483,15 @@ export const CoachBuilderProvider = ({ children }) => {
       const { data: { user }, error: userError } = await supabase.auth.getUser();
       if (userError) throw userError;
 
+      // Credit the coach to its creator. Without this a coach can never be
+      // listed, because the listing rules look for an approved creator here.
+      const creator = await fetchMyCreatorProfile();
+
       // Prepare data for database (convert empty strings to null for enum fields)
       const dbData = {
         user_id: user.id,
         user_email: userEmail,
+        creator_id: creator?.id || null,
         name: coachData.name,
         handle: coachData.handle,
         description: coachData.description,

--- a/webapp/src/hooks/useCreatorProfile.js
+++ b/webapp/src/hooks/useCreatorProfile.js
@@ -1,0 +1,35 @@
+import { useCallback, useEffect, useState } from 'react';
+import { fetchMyCreatorProfile } from '../utils/creators';
+
+/**
+ * The signed-in user's creator profile, or null when they have not made one.
+ * `creator.status` is pending | approved | suspended and is set by the
+ * platform — never by this client.
+ */
+export function useCreatorProfile() {
+  const [creator, setCreator] = useState(null);
+  const [loading, setLoading] = useState(true);
+
+  const reload = useCallback(async () => {
+    setLoading(true);
+    try {
+      const profile = await fetchMyCreatorProfile();
+      setCreator(profile);
+      return profile;
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    let cancelled = false;
+    fetchMyCreatorProfile()
+      .then((profile) => { if (!cancelled) setCreator(profile); })
+      .finally(() => { if (!cancelled) setLoading(false); });
+    return () => { cancelled = true; };
+  }, []);
+
+  return { creator, setCreator, loading, reload };
+}
+
+export default useCreatorProfile;

--- a/webapp/src/utils/creators.js
+++ b/webapp/src/utils/creators.js
@@ -1,0 +1,288 @@
+import { supabase } from '../main';
+
+// Mirrors the creator_slug_format CHECK on creator_profiles. Kept here so the
+// form can reject a bad handle before Postgres has to.
+export const CREATOR_SLUG_PATTERN = /^[a-z0-9][a-z0-9-]{1,38}[a-z0-9]$/;
+
+export const CREATOR_SLUG_RULE =
+  '3–40 characters: lowercase letters, numbers and hyphens, starting and ending with a letter or number.';
+
+// Everything else on creator_profiles — status, revenue_share_bps, the payout
+// columns — is platform-owned. A creator never sends them; the database
+// discards them if they try.
+export const CREATOR_EDITABLE_FIELDS = [
+  'display_name',
+  'slug',
+  'bio',
+  'avatar_url',
+  'website_url',
+  'social_links',
+];
+
+export const CREATOR_SOCIAL_PLATFORMS = [
+  { key: 'instagram', label: 'Instagram', placeholder: '@handle or profile URL' },
+  { key: 'youtube', label: 'YouTube', placeholder: 'Channel URL' },
+  { key: 'tiktok', label: 'TikTok', placeholder: '@handle or profile URL' },
+  { key: 'x', label: 'X / Twitter', placeholder: '@handle or profile URL' },
+  { key: 'spotify', label: 'Spotify', placeholder: 'Artist URL' },
+];
+
+export const CREATOR_PENDING_MESSAGE =
+  'Your creator account is still under review. You can keep building and previewing — we will publish this coach to the roster as soon as you are approved.';
+
+export const CREATOR_SUSPENDED_MESSAGE =
+  'Your creator account is suspended, so coaches cannot be published. Get in touch and we will take another look.';
+
+/** Turn a display name into a plausible starting handle. */
+export function slugifyCreatorName(value) {
+  return (value || '')
+    .toLowerCase()
+    .normalize('NFKD')
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, 40)
+    .replace(/-+$/g, '');
+}
+
+/** Returns a human-readable problem with the handle, or null when it is fine. */
+export function validateCreatorSlug(slug) {
+  const value = (slug || '').trim();
+  if (!value) return 'Pick a handle — it becomes your public creator URL.';
+  if (value !== value.toLowerCase()) return `Handles are lowercase. Try "${value.toLowerCase()}".`;
+  if (value.length < 3) return 'Handles need at least 3 characters.';
+  if (value.length > 40) return 'Handles can be at most 40 characters.';
+  if (/[^a-z0-9-]/.test(value)) return `Handles can only contain lowercase letters, numbers and hyphens — ${CREATOR_SLUG_RULE}`;
+  if (!CREATOR_SLUG_PATTERN.test(value)) return `Handles must start and end with a letter or number — ${CREATOR_SLUG_RULE}`;
+  return null;
+}
+
+export function validateCreatorForm(form) {
+  const errors = {};
+  if (!form.display_name || !form.display_name.trim()) {
+    errors.display_name = 'Tell people what to call you.';
+  }
+  const slugError = validateCreatorSlug(form.slug);
+  if (slugError) errors.slug = slugError;
+  for (const field of ['avatar_url', 'website_url']) {
+    const value = (form[field] || '').trim();
+    if (value && !/^https?:\/\/\S+$/i.test(value)) {
+      errors[field] = 'Use a full URL starting with http:// or https://';
+    }
+  }
+  return errors;
+}
+
+/** Only ever sends the columns a creator owns. */
+export function creatorSubmission(form) {
+  const payload = {};
+  for (const field of CREATOR_EDITABLE_FIELDS) {
+    const value = form[field];
+    if (field === 'social_links') {
+      const links = {};
+      for (const [key, link] of Object.entries(value || {})) {
+        if (link && String(link).trim()) links[key] = String(link).trim();
+      }
+      payload.social_links = links;
+    } else {
+      const trimmed = typeof value === 'string' ? value.trim() : value;
+      payload[field] = trimmed || null;
+    }
+  }
+  payload.display_name = (form.display_name || '').trim();
+  payload.slug = (form.slug || '').trim().toLowerCase();
+  return payload;
+}
+
+/** The signed-in user's creator profile, or null if they have not made one. */
+export async function fetchMyCreatorProfile() {
+  const { data: { user }, error: userError } = await supabase.auth.getUser();
+  if (userError || !user) return null;
+
+  const { data, error } = await supabase
+    .from('creator_profiles')
+    .select('*')
+    .eq('user_id', user.id)
+    .maybeSingle();
+
+  if (error) {
+    console.warn('Failed to load creator profile:', error);
+    return null;
+  }
+  return data || null;
+}
+
+export async function isCreatorSlugAvailable(slug) {
+  const { data, error } = await supabase.rpc('creator_slug_available', { p_slug: slug });
+  if (error) {
+    // Availability is a courtesy check; the unique constraint is the real one.
+    console.warn('Handle availability check failed:', error);
+    return true;
+  }
+  return data !== false;
+}
+
+export async function createCreatorProfile(form) {
+  const { data: { user }, error: userError } = await supabase.auth.getUser();
+  if (userError || !user) throw new Error('You must be signed in to become a creator.');
+
+  const payload = {
+    ...creatorSubmission(form),
+    user_id: user.id,
+    user_email: user.email,
+  };
+
+  const { data, error } = await supabase
+    .from('creator_profiles')
+    .insert(payload)
+    .select()
+    .single();
+
+  if (error) throw new Error(describeCreatorError(error, payload.slug));
+  return data;
+}
+
+export async function updateCreatorProfile(creatorId, form) {
+  const payload = creatorSubmission(form);
+  const { data, error } = await supabase
+    .from('creator_profiles')
+    .update(payload)
+    .eq('id', creatorId)
+    .select()
+    .single();
+
+  if (error) throw new Error(describeCreatorError(error, payload.slug));
+  return data;
+}
+
+/** Postgres errors, said out loud. */
+export function describeCreatorError(error, slug) {
+  const code = error?.code;
+  const message = error?.message || '';
+
+  if (code === '23505' || /duplicate key/i.test(message)) {
+    if (/creator_profiles_user_id_key/.test(message)) {
+      return 'You already have a creator profile on this account.';
+    }
+    return slug
+      ? `The handle "${slug}" is already taken. Try another.`
+      : 'That handle is already taken. Try another.';
+  }
+  if (code === '23514' || /violates check constraint/i.test(message)) {
+    if (/creator_slug_format/.test(message)) {
+      return `That handle is not valid — ${CREATOR_SLUG_RULE}`;
+    }
+    return 'Some of those details are not valid. Check the highlighted fields and try again.';
+  }
+  if (code === '42501' || /row-level security|insufficient/i.test(message)) {
+    return 'You are not allowed to change that. Sign in again and retry.';
+  }
+  return message || 'Something went wrong. Please try again.';
+}
+
+// ---------------------------------------------------------------------------
+// Publishing
+// ---------------------------------------------------------------------------
+
+export const LISTING_LABELS = {
+  draft: 'Draft',
+  in_review: 'In review',
+  listed: 'Listed',
+  unlisted: 'Unlisted',
+  rejected: 'Rejected',
+};
+
+export function listingBadgeClass(status) {
+  switch (status) {
+    case 'listed': return 'bg-green-100 text-green-800';
+    case 'in_review': return 'bg-yellow-100 text-yellow-800';
+    case 'unlisted': return 'bg-orange-100 text-orange-800';
+    case 'rejected': return 'bg-red-100 text-red-800';
+    default: return 'bg-gray-100 text-gray-700';
+  }
+}
+
+/**
+ * enforce_coach_listing_rules() raises insufficient_privilege, and the RLS
+ * WITH CHECK on coach_profiles fails with the same SQLSTATE. Either way the
+ * cause is the same and the creator should hear it in their own terms.
+ */
+export function describeListingError(error) {
+  const code = error?.code;
+  const message = error?.message || '';
+  if (code === '42501' || /insufficient|row-level security|no approved creator/i.test(message)) {
+    return CREATOR_PENDING_MESSAGE;
+  }
+  return message || 'Could not update this coach. Please try again.';
+}
+
+/**
+ * Walks a coach along draft → in_review → listed.
+ *
+ * Submitting for review is always allowed; reaching the roster is not. A
+ * pending creator lands on in_review and is told why, rather than being handed
+ * a Postgres error.
+ *
+ * Returns { listing_status, listed, message }.
+ */
+export async function publishCoach(coach, creator) {
+  if (!creator) {
+    const err = new Error('Create your creator profile before publishing a coach.');
+    err.needsCreatorProfile = true;
+    throw err;
+  }
+
+  // Coaches built before the creator profile existed have no creator_id.
+  if (coach.creator_id !== creator.id) {
+    const { error } = await supabase
+      .from('coach_profiles')
+      .update({ creator_id: creator.id })
+      .eq('id', coach.id);
+    if (error) throw new Error(describeListingError(error));
+  }
+
+  if (coach.listing_status !== 'in_review' && coach.listing_status !== 'listed') {
+    const { error } = await supabase
+      .from('coach_profiles')
+      .update({ listing_status: 'in_review' })
+      .eq('id', coach.id);
+    if (error) throw new Error(describeListingError(error));
+  }
+
+  if (creator.status !== 'approved') {
+    return {
+      listing_status: 'in_review',
+      listed: false,
+      message: creator.status === 'suspended' ? CREATOR_SUSPENDED_MESSAGE : CREATOR_PENDING_MESSAGE,
+    };
+  }
+
+  const { error } = await supabase
+    .from('coach_profiles')
+    .update({ listing_status: 'listed', public: true, active: true })
+    .eq('id', coach.id);
+
+  if (error) {
+    // The creator row said approved but the database disagreed — trust the
+    // database and leave the coach queued.
+    return {
+      listing_status: 'in_review',
+      listed: false,
+      message: describeListingError(error),
+    };
+  }
+
+  return {
+    listing_status: 'listed',
+    listed: true,
+    message: `${coach.name} is live on the roster.`,
+  };
+}
+
+export async function unlistCoach(coach) {
+  const { error } = await supabase
+    .from('coach_profiles')
+    .update({ listing_status: 'unlisted', public: false })
+    .eq('id', coach.id);
+  if (error) throw new Error(describeListingError(error));
+  return { listing_status: 'unlisted', listed: false, message: `${coach.name} has been taken off the roster.` };
+}


### PR DESCRIPTION
Closes #10.

**Stacked on #17** (`web/de-fitness-surfaces`) — that PR rewrote `PersonalityQuestionnaire.jsx` and `CoachBuilderContext.jsx`, both of which this one also touches, so the base is set to `web/de-fitness-surfaces` rather than `main`. Merge #17 first; GitHub will retarget this to `main` automatically.

---

## What this does

Becoming a creator was a manual `INSERT` and publishing a coach was manual SQL. Both are now first-class in the web app, with approval kept firmly on the platform's side of the line.

**1. Creator signup — `webapp/src/components/Creator/CreatorProfilePage.jsx`, route `/creator`.**
Display name, handle, bio, avatar, website and social links. The handle is validated client-side against the same `^[a-z0-9][a-z0-9-]{1,38}[a-z0-9]$` the CHECK constraint uses, so a bad one gets "Handles must start and end with a letter or number" rather than a constraint violation. Availability is checked through a new `creator_slug_available()` definer function, because "Anyone can view approved creators" hides pending rows — a plain client-side lookup would report a taken handle as free and then fail on the unique index.

**2. Approval state, stated honestly.**
`CreatorStatusBanner` says what is actually true at each state: a pending creator can build, preview, edit and chat, and what they are waiting on is the roster. The banner appears on `/creator` and above the coach grid whenever the account is not approved. `/creator` also shows the platform terms — status, revenue share, payout provider — as read-only, next to a line saying nothing the form submits can change them.

**3. Publish control — `webapp/src/components/MyCoaches/CoachDashboard.jsx`.**
The old Public/Private toggle on `coach_profiles.public` is replaced with a listing control that walks `draft → in_review → listed`. Submitting for review always succeeds and is recorded. Reaching the roster is the database's decision; when `enforce_coach_listing_rules()` raises `insufficient_privilege`, the coach stays queued at `in_review` and the creator is told *"Your creator account is still under review. You can keep building and previewing — we will publish this coach to the roster as soon as you are approved."* The raw Postgres error is never surfaced. RLS `WITH CHECK` failures carry the same SQLSTATE and are mapped identically, because the cause is the same.

**4. Admin approval — extends `AdminDashboard.jsx` and `functions/admin-api/index.js`.**
The dashboard grows a Creators tab (pending queue by default, with search, per-creator coach counts, a details drawer, Approve / Suspend, and revenue-share editing). Every action goes through `admin-api` behind the existing `requireAdmin()`; no service-role key goes anywhere near the browser bundle — it could not work from the browser, since `protect_creator_platform_fields()` only stands aside when `auth.uid()` is null. New endpoints: `GET /creators`, `PATCH /creators/:id`, `GET /creators/:id/coaches`. Approving publishes whatever the creator already queued at `in_review`; suspending pulls their listed coaches back to `unlisted`.

**5. `creator_id` on new coaches — `CoachBuilderContext.jsx`.**
Attached in both `saveCoach` and the `enableLiveResponses` draft insert, alongside the domain fields #17 added. Coaches built before a creator profile existed get attributed on their first publish.

## Migration — `20260811120000_creator_self_signup.sql`

Writing the signup form surfaced that the INSERT path was unguarded:

- **`protect_creator_platform_fields()` now fires on INSERT too.** The old trigger was UPDATE-only, which was fine while creators were created by the platform. An end-user INSERT could set `status = 'approved'` and `revenue_share_bps = 10000` and they would stick. Now the row is normalised — `user_id` and `user_email` from the session, `pending`, 7000 bps, no payout columns — rather than rejected, so the form never has to know those columns exist.
- **One creator profile per account** (partial unique index on `user_id`).
- **`creator_slug_available(text)`** — answers the availability question without leaking the hidden row.
- **`enforce_coach_listing_rules()` also checks that `creator_id` is yours.** It only asked whether the creator was *approved*, not whether it was *yours*. The RLS `WITH CHECK` does ask, but the legacy phone-claim UPDATE policy is permissive and ORs with it, so a phone-authenticated owner could credit their coach to any approved creator and list it under their name.
- **`anon` gets column-level SELECT on `creator_profiles`** — the public face only (`display_name`, `slug`, `bio`, `avatar_url`, `website_url`, `social_links`, `status`), never `revenue_share_bps` or `payout_account_id`. Without any grant, a signed-out reader could not resolve the creator behind a listed coach at all.

Idempotent, and applies from scratch against `mobile/e2e/harness/supabase-shim.sql`.

## Acceptance path, evidenced

New probe `mobile/e2e/creator-probe.mjs` — **39 checks, all green** — walks the acceptance criteria through PostgREST as real authenticated users, so RLS and both triggers are genuinely in play:

```
### A brand-new account creates a creator profile
  ok    malformed handle rejected
  ok      → names the slug constraint, so the UI can explain it
  ok    creator profile created
  ok      → status is pending, not what the client asked for
  ok      → revenue_share_bps is the platform default
  ok      → payout columns ignored
  ok      → user_email taken from the session
  ok    creator_slug_available: taken handle, even though RLS hides the row
  ok    one creator profile per account

### Pending creator builds a coach
  ok    coach created with creator_id attached
  ok      → starts as a draft
  ok    pending creator can still edit their draft

### A coach cannot be credited to someone else's creator profile
  ok    borrowing an approved creator_id is refused

### Publishing fails while the creator is under review
  ok    draft → in_review is allowed
  ok    in_review → listed is refused
  ok      → as insufficient_privilege, which the web app renders as
          "your creator account is still under review"
  ok      → the coach stays queued at in_review
  ok      → and is absent from get_coach_roster()

### The creator cannot approve themselves
  ok    self-approval write is accepted but neutered
  ok      → status still pending
  ok      → revenue_share_bps still 7000
  ok      → but their own fields still save

### An admin approves them (service role, as admin-api does)
  ok    approval lands on the service role
  ok    queued coaches are published with the approval
  ok    the coach appears in get_coach_roster()
  ok      → credited to the creator
  ok      → with their handle

### An approved creator can now publish from the app
  ok    in_review → listed now succeeds as the creator themselves
  ok    the creator can take it back off the roster

### Suspension pulls the listings
  ok    listed coaches are unlisted with the suspension
  ok      → and a suspended creator cannot re-list

39 passed, 0 failed
```

The admin half was also driven over HTTP against the **real `admin-api` function** (functions-framework, local Supabase), not just the service-role client:

- `GET /creators?status=pending` → the pending creator with `coach_counts: {total: 1, listed: 0, in_review: 1}`
- `PATCH /creators/:id {"status":"approved"}` → `status: "approved"`, `coaches_changed: [{name: "HTTP Probe Coach", listing_status: "listed"}]`
- `get_coach_roster()` as `anon` then returns the coach with `creator_name: "HTTP Probe Creator"`, `creator_slug: "http-probe-…"`
- the signed-out coach-detail embed `coach_profiles → creator_profiles(display_name, slug, avatar_url)` resolves
- `PATCH` with `{"status":"boss"}` → 400; no `Authorization` header → 401

## Checks

| Check | Result |
| ----- | ------ |
| `mobile/e2e/rls-probe.mjs` | 41 passed, 0 failed |
| `mobile/e2e/flow-probe.mjs` | 34 passed, 0 failed |
| `mobile/e2e/viz-realtime-probe.mjs` | 17 passed, 0 failed |
| `mobile/e2e/creator-probe.mjs` (new) | 39 passed, 0 failed |
| `cd mobile && npx tsc --noEmit` | clean |
| `node --check functions/admin-api/index.js` | clean |
| `cd _infra && terraform validate` | Success |
| `cd webapp && npm run build` | built in 1.85s |
| migration chain from scratch vs `supabase-shim.sql` | applies clean |

## Notes for review

- **`revenue_share_bps` and `status` are unreachable from the creator, by construction.** The web client only ever sends `CREATOR_EDITABLE_FIELDS`; the trigger discards the rest on both INSERT and UPDATE; the probe submits a hostile payload on both paths and asserts nothing moved.
- **Approved creators' payout terms are readable by any signed-in user.** `authenticated` holds table-level `SELECT` on `creator_profiles` and the "Anyone can view approved creators" policy admits every approved row, so `revenue_share_bps` and `payout_account_id` come along. `anon` is now limited to the public columns; `authenticated` is not, because a creator has to be able to read their own split. Splitting the two needs a view or a definer function — logged under Known follow-ups in `docs/multi-domain-coaches.md` rather than fixed here.
- `20260810120200_app_identity_and_conversations.sql` is not re-runnable a second time on an already-migrated database (pre-existing, unrelated). The new migration is.
- No infra change beyond the `admin-api` description string — the function already receives `SUPABASE_SERVICE_ROLE_KEY`, `ADMIN_EMAILS` and `ADMIN_PHONES`.
