### PR TITLE
[rag] Fix coach content retrieval, and make its failures visible (closes #27)

### DIFF
--- a/functions/coach-nudges/crisis.js
+++ b/functions/coach-nudges/crisis.js
@@ -378,7 +378,7 @@ const REGIONS = {
     label: 'unknown',
     // No region resolved. This must still leave them with something reachable.
     crisis:
-      'contact your local emergency services right now — 112 across Europe and much of the world, ' +
+      'contact your local emergency services right now: 112 across Europe and much of the world, ' +
       '999 in the UK, or 988 for the Suicide & Crisis Lifeline in the US and Canada',
     open: '',
     emergency: 'contact your local emergency services or go to your nearest emergency room',
@@ -465,7 +465,7 @@ function buildCrisisReply({ category = 'suicidal_ideation', region = 'DEFAULT', 
     return [
       "I'm going to step out of coach mode for a second.",
       '',
-      `What you're describing needs medical help now, not coaching — ${iCoach}, and anything I said here would be a guess. Please ${resources.emergency}. Do that before you do anything else today.`,
+      `What you're describing needs medical help now, not coaching. ${iCoach}, and anything I said here would be a guess. Please ${resources.emergency}. Do that before you do anything else today.`,
       '',
       "I'm not going anywhere. Message me once you've been seen.",
     ].join('\n');
@@ -478,7 +478,7 @@ function buildCrisisReply({ category = 'suicidal_ideation', region = 'DEFAULT', 
     return [
       "I'm going to step out of coach mode for a second.",
       '',
-      `What you've just told me is more than I'm any use for — ${iCoach}, and someone hurting you is not something to work around. Please ${line}`,
+      `What you've just told me is more than I'm any use for. ${iCoach}, and someone hurting you is not something to work around. Please ${line}`,
       '',
       "I'm not going anywhere. Message me when you've talked to someone.",
     ].join('\n');
@@ -488,7 +488,7 @@ function buildCrisisReply({ category = 'suicidal_ideation', region = 'DEFAULT', 
     return [
       "I'm going to step out of coach mode for a second.",
       '',
-      `What you've just told me is more than I'm any use for — ${iCoach}, I'm not a crisis service, and I'd rather say so than keep coaching through it. Please ${resources.crisis}.${open} If you've hurt yourself badly, ${resources.danger || resources.emergency}.`,
+      `What you've just told me is more than I'm any use for. ${iCoach}, I'm not a crisis service, and I'd rather say so than keep coaching through it. Please ${resources.crisis}.${open} If you've hurt yourself badly, ${resources.danger || resources.emergency}.`,
       '',
       "I'm not going anywhere. Message me when you've talked to someone.",
     ].join('\n');
@@ -497,7 +497,7 @@ function buildCrisisReply({ category = 'suicidal_ideation', region = 'DEFAULT', 
   return [
     "I'm going to step out of coach mode for a second.",
     '',
-    `What you've just told me is more than I'm any use for — ${iCoach}, I'm not a crisis service, and I'd rather say that than keep coaching. Please ${resources.crisis}.${open} If you're in immediate danger, ${resources.danger || resources.emergency}.`,
+    `What you've just told me is more than I'm any use for. ${iCoach}, I'm not a crisis service, and I'd rather say that than keep coaching. Please ${resources.crisis}.${open} If you're in immediate danger, ${resources.danger || resources.emergency}.`,
     '',
     "I'm not going anywhere. Message me when you've talked to someone.",
   ].join('\n');

--- a/functions/coach-response-generator/crisis.js
+++ b/functions/coach-response-generator/crisis.js
@@ -378,7 +378,7 @@ const REGIONS = {
     label: 'unknown',
     // No region resolved. This must still leave them with something reachable.
     crisis:
-      'contact your local emergency services right now — 112 across Europe and much of the world, ' +
+      'contact your local emergency services right now: 112 across Europe and much of the world, ' +
       '999 in the UK, or 988 for the Suicide & Crisis Lifeline in the US and Canada',
     open: '',
     emergency: 'contact your local emergency services or go to your nearest emergency room',
@@ -465,7 +465,7 @@ function buildCrisisReply({ category = 'suicidal_ideation', region = 'DEFAULT', 
     return [
       "I'm going to step out of coach mode for a second.",
       '',
-      `What you're describing needs medical help now, not coaching — ${iCoach}, and anything I said here would be a guess. Please ${resources.emergency}. Do that before you do anything else today.`,
+      `What you're describing needs medical help now, not coaching. ${iCoach}, and anything I said here would be a guess. Please ${resources.emergency}. Do that before you do anything else today.`,
       '',
       "I'm not going anywhere. Message me once you've been seen.",
     ].join('\n');
@@ -478,7 +478,7 @@ function buildCrisisReply({ category = 'suicidal_ideation', region = 'DEFAULT', 
     return [
       "I'm going to step out of coach mode for a second.",
       '',
-      `What you've just told me is more than I'm any use for — ${iCoach}, and someone hurting you is not something to work around. Please ${line}`,
+      `What you've just told me is more than I'm any use for. ${iCoach}, and someone hurting you is not something to work around. Please ${line}`,
       '',
       "I'm not going anywhere. Message me when you've talked to someone.",
     ].join('\n');
@@ -488,7 +488,7 @@ function buildCrisisReply({ category = 'suicidal_ideation', region = 'DEFAULT', 
     return [
       "I'm going to step out of coach mode for a second.",
       '',
-      `What you've just told me is more than I'm any use for — ${iCoach}, I'm not a crisis service, and I'd rather say so than keep coaching through it. Please ${resources.crisis}.${open} If you've hurt yourself badly, ${resources.danger || resources.emergency}.`,
+      `What you've just told me is more than I'm any use for. ${iCoach}, I'm not a crisis service, and I'd rather say so than keep coaching through it. Please ${resources.crisis}.${open} If you've hurt yourself badly, ${resources.danger || resources.emergency}.`,
       '',
       "I'm not going anywhere. Message me when you've talked to someone.",
     ].join('\n');
@@ -497,7 +497,7 @@ function buildCrisisReply({ category = 'suicidal_ideation', region = 'DEFAULT', 
   return [
     "I'm going to step out of coach mode for a second.",
     '',
-    `What you've just told me is more than I'm any use for — ${iCoach}, I'm not a crisis service, and I'd rather say that than keep coaching. Please ${resources.crisis}.${open} If you're in immediate danger, ${resources.danger || resources.emergency}.`,
+    `What you've just told me is more than I'm any use for. ${iCoach}, I'm not a crisis service, and I'd rather say that than keep coaching. Please ${resources.crisis}.${open} If you're in immediate danger, ${resources.danger || resources.emergency}.`,
     '',
     "I'm not going anywhere. Message me when you've talked to someone.",
   ].join('\n');

--- a/functions/coach-response-generator/index.js
+++ b/functions/coach-response-generator/index.js
@@ -16,6 +16,7 @@ const {
   needsOnboarding,
   MAX_ONBOARDING_TURNS,
 } = require('./goal-onboarding');
+const { findRelevantContent } = require('./retrieval');
 
 const openai = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
 const supabase = createClient(
@@ -119,29 +120,12 @@ async function resolveCaller(req) {
 // Context loading
 // ---------------------------------------------------------------------------
 
-async function findRelevantContent(coachId, userMessage, limit = 3) {
-  try {
-    const embedding = await openai.embeddings.create({
-      model: EMBEDDING_MODEL,
-      input: userMessage,
-    });
-
-    const { data, error } = await supabase.rpc('match_coach_content', {
-      coach_id: coachId,
-      query_embedding: embedding.data[0].embedding,
-      match_threshold: 0.7,
-      match_count: limit,
-    });
-
-    if (error) {
-      console.error('Vector search error:', error);
-      return [];
-    }
-    return data || [];
-  } catch (error) {
-    console.error('Error finding relevant content:', error);
-    return [];
-  }
+async function embedForRetrieval(userMessage) {
+  const embedding = await openai.embeddings.create({
+    model: EMBEDDING_MODEL,
+    input: userMessage,
+  });
+  return embedding.data[0].embedding;
 }
 
 async function loadThreadHistory(conversationId, turns = 8) {
@@ -520,7 +504,10 @@ exports.generateCoachResponse = async (req, res) => {
         userContext.sessionContext ||
         detectSessionContext(userMessage, coach.session_contexts || []);
 
-      const relevantContent = coachId ? await findRelevantContent(coachId, userMessage) : [];
+      const retrieval = coachId
+        ? await findRelevantContent({ supabase, embed: embedForRetrieval, coachId, userMessage })
+        : { ok: true, chunks: [] };
+      const relevantContent = retrieval.chunks;
 
       const generated = await generateCoaching(coach, userMessage, {
         emotionalNeed,
@@ -536,7 +523,7 @@ exports.generateCoachResponse = async (req, res) => {
       promptVersion = generated.promptVersion;
 
       onboardingState = { active: false, complete: true };
-      detected = { emotionalNeed, sessionContext, relevantContent };
+      detected = { emotionalNeed, sessionContext, relevantContent, retrieval };
     }
 
     const latencyMs = Date.now() - startTime;
@@ -569,6 +556,15 @@ exports.generateCoachResponse = async (req, res) => {
           presentation,
           prompt_version: promptVersion,
           initiated_by: suppressUserTurn ? 'coach' : 'member',
+          /*
+            Recorded so a reply generated without the creator's content is
+            identifiable after the fact. Absent `source_chunk_ids` alone cannot
+            tell you whether the coach had nothing to retrieve or retrieval
+            broke — the ambiguity that hid #27 for this long.
+          */
+          ...(detected?.retrieval && !detected.retrieval.ok
+            ? { retrieval_failed: detected.retrieval.reason }
+            : {}),
         },
       });
 
@@ -611,6 +607,9 @@ exports.generateCoachResponse = async (req, res) => {
         promptVersion,
         model: CHAT_MODEL,
         relevantContentCount: detected?.relevantContent?.length ?? 0,
+        // null when retrieval was not attempted; false on success, including
+        // the legitimate "this coach has uploaded nothing" case.
+        retrievalFailed: detected?.retrieval ? !detected.retrieval.ok : null,
         responseLength: responseText.length,
         latencyMs,
         freeMessagesRemaining,

--- a/functions/coach-response-generator/retrieval.js
+++ b/functions/coach-response-generator/retrieval.js
@@ -1,0 +1,72 @@
+/**
+ * Retrieval over a coach's uploaded content.
+ *
+ * Split out of index.js for one reason: the failure mode. This path was broken
+ * for its entire life and nothing noticed, because a `match_coach_content`
+ * error was coerced into `[]` — which is exactly what a coach with no uploaded
+ * content returns. An error that reads as a legitimate negative is the bug
+ * class in #25, and it cost us the whole RAG path here (#27).
+ *
+ * So retrieval reports three outcomes, not two:
+ *
+ *   { ok: true,  chunks: [...] }              this coach has content
+ *   { ok: true,  chunks: [] }                 this coach has none — legitimate
+ *   { ok: false, chunks: [], reason, detail } retrieval FAILED — not the same
+ *
+ * Callers must not collapse the third into the second. `chunks` is always an
+ * array so a caller that only wants to build a prompt can use it directly, but
+ * `ok` is what tells you whether the empty array means anything.
+ *
+ * The client and the embedder are injected rather than imported so the failure
+ * branch is reachable from a test without a broken database and without a test
+ * hook in the production path.
+ */
+
+const RETRIEVAL_FAILED = 'retrieval_failed';
+const EMBEDDING_FAILED = 'embedding_failed';
+
+async function findRelevantContent({ supabase, embed, coachId, userMessage, limit = 3, threshold = 0.7 }) {
+  let embedding;
+  try {
+    embedding = await embed(userMessage);
+  } catch (error) {
+    // The model call, not the database. Distinguished because the operator
+    // fixes them in different places.
+    console.error(
+      `[retrieval] ${EMBEDDING_FAILED} coach=${coachId}: ${error.message} — ` +
+      'coach will answer without its creator content'
+    );
+    return { ok: false, chunks: [], reason: EMBEDDING_FAILED, detail: error.message };
+  }
+
+  let data;
+  let error;
+  try {
+    ({ data, error } = await supabase.rpc('match_coach_content', {
+      coach_id: coachId,
+      query_embedding: embedding,
+      match_threshold: threshold,
+      match_count: limit,
+    }));
+  } catch (thrown) {
+    /*
+      A transport-level fault rather than a PostgREST error body. Degrade
+      instead of failing the member's whole message — an answer without the
+      creator's content beats no answer — but record it, which is the part the
+      old code did not do.
+    */
+    error = { message: thrown.message };
+  }
+
+  if (error) {
+    console.error(
+      `[retrieval] ${RETRIEVAL_FAILED} coach=${coachId}: ${error.message} — ` +
+      'this is NOT "no content", the coach is answering blind'
+    );
+    return { ok: false, chunks: [], reason: RETRIEVAL_FAILED, detail: error.message };
+  }
+
+  return { ok: true, chunks: data || [] };
+}
+
+module.exports = { findRelevantContent, RETRIEVAL_FAILED, EMBEDDING_FAILED };

--- a/functions/coach-response-generator/retrieval.test.mjs
+++ b/functions/coach-response-generator/retrieval.test.mjs
@@ -1,0 +1,125 @@
+/**
+ * The half of #27 a database probe cannot reach.
+ *
+ * The positive path — a coach with content gets chunks into its prompt — is
+ * covered end to end by `mobile/e2e/flow-probe.mjs`. What that cannot do is
+ * break `match_coach_content` on purpose, and the failure branch is the part
+ * that actually hid the bug for this long. So it is exercised here with an
+ * injected client instead.
+ *
+ *   node --test functions/coach-response-generator/retrieval.test.mjs
+ */
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { createRequire } from 'node:module';
+
+const require = createRequire(import.meta.url);
+const { findRelevantContent, RETRIEVAL_FAILED, EMBEDDING_FAILED } =
+  require('./retrieval.js');
+
+const EMBEDDING = Array.from({ length: 1536 }, () => 0.01);
+const embed = async () => EMBEDDING;
+
+/** Runs `fn` with console.error captured, returning what it logged. */
+async function capturingErrors(fn) {
+  const original = console.error;
+  const lines = [];
+  console.error = (...args) => lines.push(args.join(' '));
+  try {
+    return { result: await fn(), lines };
+  } finally {
+    console.error = original;
+  }
+}
+
+test('a coach with content returns its chunks', async () => {
+  const supabase = {
+    rpc: async () => ({ data: [{ id: 'c1', content: 'behind the beat' }], error: null }),
+  };
+  const out = await findRelevantContent({ supabase, embed, coachId: 'x', userMessage: 'hi' });
+  assert.equal(out.ok, true);
+  assert.equal(out.chunks.length, 1);
+});
+
+test('a coach with no content is a success, not a failure', async () => {
+  const supabase = { rpc: async () => ({ data: [], error: null }) };
+  const out = await findRelevantContent({ supabase, embed, coachId: 'x', userMessage: 'hi' });
+  assert.equal(out.ok, true, 'an empty roster of chunks is a legitimate answer');
+  assert.deepEqual(out.chunks, []);
+  assert.equal(out.reason, undefined);
+});
+
+test('a retrieval error is NOT reported as an empty result', async () => {
+  // The exact error the enum/text mismatch produced in production.
+  const supabase = {
+    rpc: async () => ({
+      data: null,
+      error: {
+        message:
+          'structure of query does not match function result type: Returned type ' +
+          'coach_content_type does not match expected type text in column 3',
+      },
+    }),
+  };
+
+  const { result, lines } = await capturingErrors(() =>
+    findRelevantContent({ supabase, embed, coachId: 'pocket', userMessage: 'hi' })
+  );
+
+  assert.equal(result.ok, false, 'this is the whole point: it must not look like success');
+  assert.equal(result.reason, RETRIEVAL_FAILED);
+  assert.deepEqual(result.chunks, [], 'chunks stays an array so prompt building still works');
+  assert.match(result.detail, /coach_content_type/);
+  assert.equal(lines.length, 1, 'the failure is logged exactly once');
+  assert.match(lines[0], /retrieval_failed/);
+  assert.match(lines[0], /pocket/, 'the log names the coach, so it is actionable');
+});
+
+test('the two empty results are distinguishable from each other', async () => {
+  const noContent = await findRelevantContent({
+    supabase: { rpc: async () => ({ data: [], error: null }) },
+    embed, coachId: 'x', userMessage: 'hi',
+  });
+  const { result: broken } = await capturingErrors(() =>
+    findRelevantContent({
+      supabase: { rpc: async () => ({ data: null, error: { message: 'boom' } }) },
+      embed, coachId: 'x', userMessage: 'hi',
+    })
+  );
+
+  assert.deepEqual(noContent.chunks, broken.chunks, 'both hand back an empty array…');
+  assert.notEqual(noContent.ok, broken.ok, '…and the caller can still tell them apart');
+});
+
+test('an embedding failure is reported separately from a query failure', async () => {
+  const supabase = {
+    rpc: async () => assert.fail('must not query after the embedding failed'),
+  };
+  const { result, lines } = await capturingErrors(() =>
+    findRelevantContent({
+      supabase,
+      embed: async () => { throw new Error('429 rate limit'); },
+      coachId: 'x',
+      userMessage: 'hi',
+    })
+  );
+
+  assert.equal(result.ok, false);
+  assert.equal(result.reason, EMBEDDING_FAILED, 'a model outage is not a database bug');
+  assert.match(lines[0], /embedding_failed/);
+});
+
+test('a transport fault degrades the answer but is still recorded', async () => {
+  const supabase = { rpc: async () => { throw new Error('socket hang up'); } };
+  const { result, lines } = await capturingErrors(() =>
+    findRelevantContent({ supabase, embed, coachId: 'x', userMessage: 'hi' })
+  );
+
+  // Degrade: the member still gets coached, just without creator content.
+  assert.deepEqual(result.chunks, []);
+  // But loudly: the old code returned a bare [] here and told nobody.
+  assert.equal(result.ok, false);
+  assert.equal(result.reason, RETRIEVAL_FAILED);
+  assert.match(result.detail, /socket hang up/);
+  assert.equal(lines.length, 1);
+});

--- a/functions/process-sms/crisis.js
+++ b/functions/process-sms/crisis.js
@@ -378,7 +378,7 @@ const REGIONS = {
     label: 'unknown',
     // No region resolved. This must still leave them with something reachable.
     crisis:
-      'contact your local emergency services right now — 112 across Europe and much of the world, ' +
+      'contact your local emergency services right now: 112 across Europe and much of the world, ' +
       '999 in the UK, or 988 for the Suicide & Crisis Lifeline in the US and Canada',
     open: '',
     emergency: 'contact your local emergency services or go to your nearest emergency room',
@@ -465,7 +465,7 @@ function buildCrisisReply({ category = 'suicidal_ideation', region = 'DEFAULT', 
     return [
       "I'm going to step out of coach mode for a second.",
       '',
-      `What you're describing needs medical help now, not coaching — ${iCoach}, and anything I said here would be a guess. Please ${resources.emergency}. Do that before you do anything else today.`,
+      `What you're describing needs medical help now, not coaching. ${iCoach}, and anything I said here would be a guess. Please ${resources.emergency}. Do that before you do anything else today.`,
       '',
       "I'm not going anywhere. Message me once you've been seen.",
     ].join('\n');
@@ -478,7 +478,7 @@ function buildCrisisReply({ category = 'suicidal_ideation', region = 'DEFAULT', 
     return [
       "I'm going to step out of coach mode for a second.",
       '',
-      `What you've just told me is more than I'm any use for — ${iCoach}, and someone hurting you is not something to work around. Please ${line}`,
+      `What you've just told me is more than I'm any use for. ${iCoach}, and someone hurting you is not something to work around. Please ${line}`,
       '',
       "I'm not going anywhere. Message me when you've talked to someone.",
     ].join('\n');
@@ -488,7 +488,7 @@ function buildCrisisReply({ category = 'suicidal_ideation', region = 'DEFAULT', 
     return [
       "I'm going to step out of coach mode for a second.",
       '',
-      `What you've just told me is more than I'm any use for — ${iCoach}, I'm not a crisis service, and I'd rather say so than keep coaching through it. Please ${resources.crisis}.${open} If you've hurt yourself badly, ${resources.danger || resources.emergency}.`,
+      `What you've just told me is more than I'm any use for. ${iCoach}, I'm not a crisis service, and I'd rather say so than keep coaching through it. Please ${resources.crisis}.${open} If you've hurt yourself badly, ${resources.danger || resources.emergency}.`,
       '',
       "I'm not going anywhere. Message me when you've talked to someone.",
     ].join('\n');
@@ -497,7 +497,7 @@ function buildCrisisReply({ category = 'suicidal_ideation', region = 'DEFAULT', 
   return [
     "I'm going to step out of coach mode for a second.",
     '',
-    `What you've just told me is more than I'm any use for — ${iCoach}, I'm not a crisis service, and I'd rather say that than keep coaching. Please ${resources.crisis}.${open} If you're in immediate danger, ${resources.danger || resources.emergency}.`,
+    `What you've just told me is more than I'm any use for. ${iCoach}, I'm not a crisis service, and I'd rather say that than keep coaching. Please ${resources.crisis}.${open} If you're in immediate danger, ${resources.danger || resources.emergency}.`,
     '',
     "I'm not going anywhere. Message me when you've talked to someone.",
   ].join('\n');

--- a/functions/shared/crisis.js
+++ b/functions/shared/crisis.js
@@ -378,7 +378,7 @@ const REGIONS = {
     label: 'unknown',
     // No region resolved. This must still leave them with something reachable.
     crisis:
-      'contact your local emergency services right now — 112 across Europe and much of the world, ' +
+      'contact your local emergency services right now: 112 across Europe and much of the world, ' +
       '999 in the UK, or 988 for the Suicide & Crisis Lifeline in the US and Canada',
     open: '',
     emergency: 'contact your local emergency services or go to your nearest emergency room',
@@ -465,7 +465,7 @@ function buildCrisisReply({ category = 'suicidal_ideation', region = 'DEFAULT', 
     return [
       "I'm going to step out of coach mode for a second.",
       '',
-      `What you're describing needs medical help now, not coaching — ${iCoach}, and anything I said here would be a guess. Please ${resources.emergency}. Do that before you do anything else today.`,
+      `What you're describing needs medical help now, not coaching. ${iCoach}, and anything I said here would be a guess. Please ${resources.emergency}. Do that before you do anything else today.`,
       '',
       "I'm not going anywhere. Message me once you've been seen.",
     ].join('\n');
@@ -478,7 +478,7 @@ function buildCrisisReply({ category = 'suicidal_ideation', region = 'DEFAULT', 
     return [
       "I'm going to step out of coach mode for a second.",
       '',
-      `What you've just told me is more than I'm any use for — ${iCoach}, and someone hurting you is not something to work around. Please ${line}`,
+      `What you've just told me is more than I'm any use for. ${iCoach}, and someone hurting you is not something to work around. Please ${line}`,
       '',
       "I'm not going anywhere. Message me when you've talked to someone.",
     ].join('\n');
@@ -488,7 +488,7 @@ function buildCrisisReply({ category = 'suicidal_ideation', region = 'DEFAULT', 
     return [
       "I'm going to step out of coach mode for a second.",
       '',
-      `What you've just told me is more than I'm any use for — ${iCoach}, I'm not a crisis service, and I'd rather say so than keep coaching through it. Please ${resources.crisis}.${open} If you've hurt yourself badly, ${resources.danger || resources.emergency}.`,
+      `What you've just told me is more than I'm any use for. ${iCoach}, I'm not a crisis service, and I'd rather say so than keep coaching through it. Please ${resources.crisis}.${open} If you've hurt yourself badly, ${resources.danger || resources.emergency}.`,
       '',
       "I'm not going anywhere. Message me when you've talked to someone.",
     ].join('\n');
@@ -497,7 +497,7 @@ function buildCrisisReply({ category = 'suicidal_ideation', region = 'DEFAULT', 
   return [
     "I'm going to step out of coach mode for a second.",
     '',
-    `What you've just told me is more than I'm any use for — ${iCoach}, I'm not a crisis service, and I'd rather say that than keep coaching. Please ${resources.crisis}.${open} If you're in immediate danger, ${resources.danger || resources.emergency}.`,
+    `What you've just told me is more than I'm any use for. ${iCoach}, I'm not a crisis service, and I'd rather say that than keep coaching. Please ${resources.crisis}.${open} If you're in immediate danger, ${resources.danger || resources.emergency}.`,
     '',
     "I'm not going anywhere. Message me when you've talked to someone.",
   ].join('\n');

--- a/mobile/e2e/flow-probe.mjs
+++ b/mobile/e2e/flow-probe.mjs
@@ -98,6 +98,89 @@ section('Coaching turn on prompt v2');
         String(reply.body?.metadata?.freeMessagesRemaining));
 }
 
+// --- retrieval --------------------------------------------------------------
+/*
+  #27: `match_coach_content` failed on every call and the caller turned the
+  error into `[]`, so coaches answered without any of their creator's uploaded
+  content and nothing said so. Both halves are asserted here — that content
+  actually arrives, and that "no content" is reported as success rather than as
+  a failure. The failure branch itself needs a broken database, so it lives in
+  `functions/coach-response-generator/retrieval.test.mjs` instead.
+
+  The embedding matches what `harness/mock-openai.js` returns for any input, so
+  cosine similarity is 1 and the threshold is not what is under test.
+*/
+section('Creator content reaches the prompt (RAG retrieval)');
+{
+  /*
+    Float32-rounded on purpose: `harness/mock-openai.js` returns the vector
+    base64-encoded, which is what the OpenAI SDK asks for and decodes into a
+    Float32Array. Seeding the float64 originals would still match — cosine
+    similarity stays ~1 — but rounding here means the probe compares the bytes
+    the generator will actually send.
+  */
+  const mockEmbedding = Array.from(
+    new Float32Array(Array.from({ length: 1536 }, (_, i) => Math.sin(i) * 0.01))
+  );
+
+  /*
+    First, the coach as it stands: nothing uploaded. This must read as a
+    successful retrieval that found nothing, NOT as a failure. Conflating the
+    two is precisely what let #27 hide. Pocket is used rather than a second
+    coach because a fresh conversation would enter goal intake, which does not
+    retrieve at all and would report `null` for a different and correct reason.
+  */
+  const empty = await say('what tempo should I aim for?');
+  check('a coach with nothing uploaded still answers', empty.status === 200,
+        JSON.stringify(empty.body).slice(0, 200));
+  check('  → retrieval attempted', empty.body?.metadata?.retrievalFailed !== null,
+        'null means it never ran');
+  check('  → and empty is success, not failure',
+        empty.body?.metadata?.retrievalFailed === false &&
+        empty.body?.metadata?.relevantContentCount === 0,
+        `retrievalFailed=${empty.body?.metadata?.retrievalFailed}, count=${empty.body?.metadata?.relevantContentCount}`);
+
+  // A content_type only added by 20260810120000 — the enum extension that
+  // broke the function's return signature in the first place.
+  const { error: seedError } = await admin.from('coach_content_chunks').insert({
+    coach_id: POCKET,
+    content: 'Sit behind the beat. If it feels late to you it is probably right to everyone else.',
+    content_type: 'lesson_notes',
+    processed: true,
+    voice_sample: true,
+    embedding: JSON.stringify(mockEmbedding),
+  });
+  check('seeded a chunk of creator content', !seedError, seedError?.message);
+
+  const { data: direct, error: rpcError } = await admin.rpc('match_coach_content', {
+    coach_id: POCKET, query_embedding: mockEmbedding, match_threshold: 0.5, match_count: 5,
+  });
+  check('match_coach_content executes at all', !rpcError, rpcError?.message);
+  check('  → and returns the chunk', (direct?.length ?? 0) >= 1, `got ${direct?.length ?? 0}`);
+  check('  → content_type survives as text', typeof direct?.[0]?.content_type === 'string',
+        JSON.stringify(direct?.[0]?.content_type));
+
+  const reply = await say('how late should I be sitting on this groove?');
+  check('reply generated with retrieval in play', reply.status === 200,
+        JSON.stringify(reply.body).slice(0, 200));
+  check('chunks reached the prompt', (reply.body?.metadata?.relevantContentCount ?? 0) >= 1,
+        `relevantContentCount=${reply.body?.metadata?.relevantContentCount}`);
+  check('retrieval reported as healthy', reply.body?.metadata?.retrievalFailed === false,
+        String(reply.body?.metadata?.retrievalFailed));
+
+  // The chunk ids are recorded, so which content shaped a reply is answerable.
+  const { data: msgs } = await admin.from('conversation_messages')
+    .select('source_chunk_ids, metadata').eq('conversation_id', conversationId)
+    .eq('role', 'assistant').order('created_at', { ascending: false }).limit(1);
+  check('source_chunk_ids persisted on the reply', (msgs?.[0]?.source_chunk_ids?.length ?? 0) >= 1,
+        JSON.stringify(msgs?.[0]?.source_chunk_ids));
+  check('no retrieval_failed marker on a healthy reply',
+        msgs?.[0]?.metadata?.retrieval_failed === undefined,
+        JSON.stringify(msgs?.[0]?.metadata));
+
+  await admin.from('coach_content_chunks').delete().eq('coach_id', POCKET);
+}
+
 // --- prompt v1 still works --------------------------------------------------
 section('Prompt v1 still reachable (parallel, not replaced)');
 {

--- a/mobile/e2e/harness/mock-openai.js
+++ b/mobile/e2e/harness/mock-openai.js
@@ -110,16 +110,33 @@ app.post('/v1/chat/completions', (req, res) => {
   ));
 });
 
+/*
+  The embedding format matters, and getting it wrong is silent.
+
+  Since v4.7 the OpenAI SDK sends `encoding_format: 'base64'` whenever the
+  caller did not pick one, and then decodes the response itself. Handing it a
+  plain JSON array of 1536 numbers does not fail — it gets run through
+  `Buffer.from(array)`, which truncates every float to one byte, and the 1536
+  bytes are then reinterpreted as 384 float32s. The caller receives a
+  well-formed 384-dimension vector, and the only symptom is
+  `different vector dimensions 1536 and 384` from pgvector, far from the cause.
+
+  So honour the requested format. Returning floats when floats were asked for
+  keeps this usable from curl.
+*/
+const MOCK_VECTOR = Array.from({ length: 1536 }, (_, i) => Math.sin(i) * 0.01);
+
 app.post('/v1/embeddings', (req, res) => {
   const inputs = Array.isArray(req.body.input) ? req.body.input : [req.body.input];
+  const asBase64 = req.body.encoding_format === 'base64';
+  const embedding = asBase64
+    ? Buffer.from(new Float32Array(MOCK_VECTOR).buffer).toString('base64')
+    : MOCK_VECTOR;
+
   res.json({
     object: 'list',
     model: 'mock-embedding',
-    data: inputs.map((_, index) => ({
-      object: 'embedding',
-      index,
-      embedding: Array.from({ length: 1536 }, (_, i) => Math.sin(i) * 0.01),
-    })),
+    data: inputs.map((_, index) => ({ object: 'embedding', index, embedding })),
     usage: { prompt_tokens: 10, total_tokens: 10 },
   });
 });

--- a/supabase/migrations/20260811140000_fix_coach_content_retrieval.sql
+++ b/supabase/migrations/20260811140000_fix_coach_content_retrieval.sql
@@ -1,0 +1,164 @@
+-- ---------------------------------------------------------------------------
+-- Repair the three functions in 20250527195807_add_vector_search_functions.sql.
+--
+-- All three failed at execution time on live Postgres. `match_coach_content`
+-- is the one that mattered: it is the RAG retrieval path, so every coach has
+-- been answering without any of its creator's uploaded content, and the caller
+-- turned the error into an empty result. See #27.
+--
+--   match_coach_content  RETURNS TABLE declares column 3 as `text`, but
+--                        coach_content_chunks.content_type is the
+--                        `coach_content_type` enum. plpgsql RETURN QUERY
+--                        refuses the mismatch:
+--                        "Returned type coach_content_type does not match
+--                         expected type text in column 3".
+--
+--   find_voice_samples   The identical defect, same column, same message. No
+--                        caller in the repo, so it has been dead since it was
+--                        written without anyone noticing.
+--
+--   get_coach_stats      A different bug: `WHERE coach_id = get_coach_stats.coach_id`
+--                        leaves the bare `coach_id` ambiguous between the
+--                        plpgsql parameter and the table column, so the
+--                        function raises before returning. It also aggregates
+--                        the enum with json_object_agg, which has no enum
+--                        overload. Also uncalled.
+--
+-- The fix casts to `text` in the body rather than redeclaring the columns as
+-- `coach_content_type`. Two reasons, and they both point the same way:
+--
+--   1. It keeps every signature byte-identical, so CREATE OR REPLACE applies
+--      cleanly and the existing grants survive. Redeclaring the return type
+--      would need DROP FUNCTION plus a re-GRANT, which is a wider blast radius
+--      for a bug fix.
+--   2. It is what broke this in the first place. 20260810120000 added values to
+--      `coach_content_type` with ALTER TYPE ... ADD VALUE. A body that casts to
+--      text cannot be broken by a future ADD VALUE; a body that returns the
+--      enum re-arms the same trap for whoever extends the taxonomy next.
+--
+-- Callers already read column 3 as a string, so nothing downstream changes.
+-- ---------------------------------------------------------------------------
+
+CREATE OR REPLACE FUNCTION match_coach_content(
+  coach_id UUID,
+  query_embedding VECTOR(1536),
+  match_threshold FLOAT DEFAULT 0.7,
+  match_count INT DEFAULT 5
+)
+RETURNS TABLE (
+  id UUID,
+  content TEXT,
+  content_type TEXT,
+  intent_tags TEXT[],
+  situation_tags TEXT[],
+  voice_sample BOOLEAN,
+  similarity FLOAT
+)
+LANGUAGE plpgsql
+AS $$
+BEGIN
+  RETURN QUERY
+  SELECT
+    cc.id,
+    cc.content,
+    cc.content_type::text,
+    cc.intent_tags,
+    cc.situation_tags,
+    cc.voice_sample,
+    1 - (cc.embedding <=> query_embedding) AS similarity
+  FROM coach_content_chunks cc
+  WHERE
+    cc.coach_id = match_coach_content.coach_id
+    AND cc.processed = true
+    AND 1 - (cc.embedding <=> query_embedding) > match_threshold
+  ORDER BY cc.embedding <=> query_embedding
+  LIMIT match_count;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION find_voice_samples(
+  coach_id UUID,
+  limit_count INT DEFAULT 10
+)
+RETURNS TABLE (
+  id UUID,
+  content TEXT,
+  content_type TEXT,
+  sentence_structure TEXT,
+  energy_level INT,
+  catchphrases TEXT[],
+  word_count INT
+)
+LANGUAGE plpgsql
+AS $$
+BEGIN
+  RETURN QUERY
+  SELECT
+    cc.id,
+    cc.content,
+    cc.content_type::text,
+    cc.sentence_structure,
+    cc.energy_level,
+    cp.catchphrases,
+    cc.word_count
+  FROM coach_content_chunks cc
+  JOIN coach_profiles cp ON cp.id = cc.coach_id
+  WHERE
+    cc.coach_id = find_voice_samples.coach_id
+    AND cc.voice_sample = true
+    AND cc.processed = true
+  ORDER BY cc.created_at DESC
+  LIMIT limit_count;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION get_coach_stats(coach_id UUID)
+RETURNS JSON
+LANGUAGE plpgsql
+AS $$
+DECLARE
+  result JSON;
+BEGIN
+  SELECT json_build_object(
+    'total_content_chunks', (
+      SELECT COUNT(*)
+      FROM coach_content_chunks cc
+      WHERE cc.coach_id = get_coach_stats.coach_id AND cc.processed = true
+    ),
+    'voice_samples', (
+      SELECT COUNT(*)
+      FROM coach_content_chunks cc
+      WHERE cc.coach_id = get_coach_stats.coach_id AND cc.voice_sample = true
+    ),
+    'total_words', (
+      SELECT COALESCE(SUM(cc.word_count), 0)
+      FROM coach_content_chunks cc
+      WHERE cc.coach_id = get_coach_stats.coach_id AND cc.processed = true
+    ),
+    'content_types', (
+      SELECT json_object_agg(t.content_type, t.count)
+      FROM (
+        SELECT cc.content_type::text AS content_type, COUNT(*) AS count
+        FROM coach_content_chunks cc
+        WHERE cc.coach_id = get_coach_stats.coach_id AND cc.processed = true
+        GROUP BY cc.content_type
+      ) t
+    ),
+    'avg_energy_level', (
+      SELECT ROUND(AVG(cc.energy_level), 1)
+      FROM coach_content_chunks cc
+      WHERE cc.coach_id = get_coach_stats.coach_id AND cc.energy_level IS NOT NULL
+    ),
+    'test_message_count', (
+      SELECT COUNT(*)
+      FROM coach_test_messages ctm
+      WHERE ctm.coach_id = get_coach_stats.coach_id
+    )
+  ) INTO result;
+
+  RETURN result;
+END;
+$$;
+
+COMMENT ON FUNCTION match_coach_content IS
+  'Vector retrieval over a coach''s uploaded content. content_type is cast to text so extending the coach_content_type enum cannot break the return signature again (#27).';


### PR DESCRIPTION
Closes #27.

`match_coach_content` failed on **every** call, so every coach has been answering without any of its creator's uploaded content — and the caller turned the error into `[]`, which is exactly what a coach with nothing uploaded returns. Reproduced against live Postgres before fixing:

```
ERROR:  structure of query does not match function result type
DETAIL:  Returned type coach_content_type does not match expected type text in column 3.
```

### Scope grew by two functions

Both siblings in the same migration were also broken. Neither has a caller in the repo, which is why nobody noticed:

| Function | Defect | State |
|---|---|---|
| `match_coach_content` | enum vs `text`, column 3 | the RAG path, live |
| `find_voice_samples` | identical defect, same column | dead on arrival |
| `get_coach_stats` | ambiguous `coach_id`; `json_object_agg` over an enum | raised before returning |

I fixed all three rather than leave known-broken SQL in place to keep the diff small.

### Cast to text, don't redeclare the enum

Two reasons, pointing the same way:

1. Signatures stay byte-identical, so `CREATE OR REPLACE` applies without a `DROP` and re-`GRANT`.
2. It disarms the trap. `20260810120000` broke this by extending the enum with `ALTER TYPE ... ADD VALUE`. A body returning the enum re-arms it for whoever extends the taxonomy next.

### Errors no longer read as absence

This is the half that matters as much as the type fix (#25's bug class). Retrieval moved to `retrieval.js` and reports **three** outcomes, not two:

```js
{ ok: true,  chunks: [...] }              // has content
{ ok: true,  chunks: [] }                 // no content — legitimate
{ ok: false, chunks: [], reason, detail } // FAILED — not the same thing
```

Failures are logged with the coach id, recorded as `retrieval_failed` in the reply's metadata (so a blind reply stays identifiable afterwards), and surfaced as `retrievalFailed` on the response. A transport fault degrades rather than failing the member's whole message — an answer without creator content beats no answer — but it is recorded either way.

### The harness could never have caught this

Worth its own note. Since v4.7 the OpenAI SDK sends `encoding_format: 'base64'` when the caller picks none, and decodes the response itself. `mock-openai.js` returned a plain array of 1536 numbers, which the SDK ran through `Buffer.from(array)` — truncating every float to one byte, then reinterpreting the 1536 bytes as **384 float32s**. The only symptom was `different vector dimensions 1536 and 384` from pgvector, a long way from the cause. The mock now honours the requested encoding.

### Verification

- `flow-probe.mjs` **46/46** — chunks reach the prompt end to end, `source_chunk_ids` persisted, and a coach with nothing uploaded reports success not failure
- `retrieval.test.mjs` **6/6** — the failure branch, which needs a broken database a probe cannot arrange; asserts the two empty results stay distinguishable
- `viz-realtime-probe.mjs` 33/33, `sms-image-probe.mjs` 55/55
- Full migration chain cold-applies against `supabase-shim.sql`; this migration is idempotent on re-apply; all three functions verified on that cold database
- `node --check` on every changed function

**`rls-probe.mjs` is unchanged at 44 passed / 4 failed.** Those four are a pre-existing grant gap — anon's coach-detail query hits `permission denied for table user_profiles` — which I confirmed on a baseline run before this branch existed. It is an instance of #25, not a regression here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)