### PR TITLE
[ios] In-app account deletion (App Store 5.1.1(v))

### DIFF
--- a/_infra/cloud_functions.tf
+++ b/_infra/cloud_functions.tf
@@ -66,6 +66,15 @@ resource "google_service_account" "iap_validator" {
   project      = var.project_id
 }
 
+# Its own identity rather than sharing the visualiser's: this is the only thing
+# in the estate that deletes a member outright, and "who erased this account"
+# should be answerable from the audit log without ambiguity.
+resource "google_service_account" "account_deletion" {
+  account_id   = "account-deletion"
+  display_name = "Service Account for Account Deletion Function"
+  project      = var.project_id
+}
+
 # Create conversation storage bucket
 resource "google_storage_bucket" "conversation_storage" {
   name          = "${var.project_id}-${var.conversation_bucket_name}"
@@ -178,11 +187,32 @@ resource "google_storage_bucket_iam_member" "coach_visualizer_bucket_access" {
   member = "serviceAccount:${google_service_account.coach_visualizer.email}"
 }
 
-# The only identity that may read, write or delete a member's reference photo.
+# The only identities that may read, write or delete a member's reference
+# photo: the visualiser, which stores and revokes it, and account deletion,
+# which sweeps the whole per-member prefix before erasing the account.
 resource "google_storage_bucket_iam_member" "coach_visualizer_member_media_access" {
   bucket = google_storage_bucket.member_media_bucket.name
   role   = "roles/storage.objectUser"
   member = "serviceAccount:${google_service_account.coach_visualizer.email}"
+}
+
+resource "google_project_iam_member" "account_deletion_roles" {
+  for_each = toset([
+    "roles/cloudfunctions.invoker",
+    "roles/logging.logWriter"
+  ])
+
+  project = var.project_id
+  role    = each.key
+  member  = "serviceAccount:${google_service_account.account_deletion.email}"
+}
+
+# Scoped to the member-media bucket alone. Deleting an account never needs to
+# reach the public image bucket or the conversation archive.
+resource "google_storage_bucket_iam_member" "account_deletion_member_media_access" {
+  bucket = google_storage_bucket.member_media_bucket.name
+  role   = "roles/storage.objectUser"
+  member = "serviceAccount:${google_service_account.account_deletion.email}"
 }
 
 resource "google_project_iam_member" "coach_nudges_roles" {
@@ -391,6 +421,14 @@ data "archive_file" "coach_visualizer_zip" {
   excludes    = ["node_modules"]
 }
 
+# Account deletion package
+data "archive_file" "account_deletion_zip" {
+  type        = "zip"
+  source_dir  = "${path.root}/../functions/account-deletion"
+  output_path = "${path.root}/tmp/account-deletion.zip"
+  excludes    = ["node_modules"]
+}
+
 # Coach nudges (push) package
 data "archive_file" "coach_nudges_zip" {
   type        = "zip"
@@ -497,6 +535,12 @@ resource "google_storage_bucket_object" "coach_visualizer_source" {
   name   = "coach-visualizer-${data.archive_file.coach_visualizer_zip.output_md5}.zip"
   bucket = google_storage_bucket.function_bucket.name
   source = data.archive_file.coach_visualizer_zip.output_path
+}
+
+resource "google_storage_bucket_object" "account_deletion_source" {
+  name   = "account-deletion-${data.archive_file.account_deletion_zip.output_md5}.zip"
+  bucket = google_storage_bucket.function_bucket.name
+  source = data.archive_file.account_deletion_zip.output_path
 }
 
 resource "google_storage_bucket_object" "coach_nudges_source" {
@@ -864,6 +908,43 @@ module "coach_visualizer_function" {
 resource "google_cloud_run_service_iam_member" "coach_visualizer_invoker" {
   location = module.coach_visualizer_function.function.location
   service  = module.coach_visualizer_function.function.name
+  role     = "roles/run.invoker"
+  member   = "allUsers"
+}
+
+module "account_deletion_function" {
+  source = "./modules/cloud_function"
+
+  name        = "account-deletion"
+  description = "Erases a member's account: reference photo, every row, then the auth identity"
+  region      = var.region
+  bucket_name = google_storage_bucket.function_bucket.name
+  source_object = google_storage_bucket_object.account_deletion_source.name
+  entry_point = "deleteAccount"
+  memory      = "512M"
+  # Sweeping a bucket prefix plus one transaction; nowhere near the 60s default,
+  # but a deletion that times out half way is worth avoiding outright.
+  timeout     = 120
+  service_account_email = google_service_account.account_deletion.email
+
+  environment_variables = {
+    PROJECT_ID                = var.project_id
+    SUPABASE_URL              = var.supabase_url
+    SUPABASE_SERVICE_ROLE_KEY = var.supabase_service_role_key
+    MEMBER_MEDIA_BUCKET       = google_storage_bucket.member_media_bucket.name
+    ALLOWED_ORIGINS           = var.allowed_origins
+  }
+  depends_on = [
+    google_storage_bucket_object.account_deletion_source,
+    google_storage_bucket_iam_member.account_deletion_member_media_access,
+  ]
+}
+
+# Public like the other app-facing functions: the endpoint authenticates the
+# caller from their Supabase JWT and can only ever delete that caller.
+resource "google_cloud_run_service_iam_member" "account_deletion_invoker" {
+  location = module.account_deletion_function.function.location
+  service  = module.account_deletion_function.function.name
   role     = "roles/run.invoker"
   member   = "allUsers"
 }

--- a/docs/multi-domain-coaches.md
+++ b/docs/multi-domain-coaches.md
@@ -78,6 +78,56 @@ their listings back to `unlisted`.
 rather than US-only, and RLS accepts `auth.uid()` or the email claim alongside
 the legacy phone claim. Nothing about the existing SMS funnel changed.
 
+### Deleting an account
+
+App Store Review Guideline 5.1.1(v) requires an app that creates accounts to
+delete them from inside the app, so Settings → Delete account leads to a screen
+that names what will be destroyed and gates on typing the word DELETE. The work
+happens in `functions/account-deletion`, in this order and for this reason:
+
+1. **The reference photo objects, first.** Swept by prefix across the whole
+   `member-reference/<user id>/` path rather than by the URI in
+   `reference_photo_url`, exactly as `coach-visualizer`'s likeness revocation
+   does, so a photo stored under an older extension cannot survive. The
+   member-media bucket sets `soft_delete_policy` retention to 0 so this is real.
+   If it fails, **nothing else happens** — an orphaned photograph of somebody
+   who no longer has an account is worse than a deletion they have to retry.
+2. **Every public-schema row**, through `delete_member_account()`, one
+   transaction, service role only.
+3. **The `auth.users` row**, through GoTrue's admin API so identities, sessions
+   and refresh tokens go with it.
+
+**Decided: coaches the member created are not deleted with them, and not
+orphaned either.** `20260812090000` first defuses the two foreign keys that made
+the question urgent — `coach_profiles.user_id` and `.user_email` both cascaded,
+so deleting one person destroyed every coach they owned and, through those,
+other members' subscriptions, threads and goals. Both are now `ON DELETE SET
+NULL`, and the function decides explicitly instead:
+
+| Case | Outcome |
+| ---- | ------- |
+| Attributed to another creator (this is the five default personas, which still carry the founder's address in the legacy `user_email` column) | **Detached.** `user_id` and `user_email` cleared; listing and attribution untouched. |
+| Theirs, and other members are subscribed or have threads | **Retained and unlisted.** It keeps working for the people paying for it; nobody new can subscribe to a coach with nobody behind it. |
+| Theirs, and nobody else uses it | **Deleted**, with its content chunks and store products. |
+
+Their `creator_profiles` row is deleted if no coach still points at it, and
+otherwise survives with `user_id`, name, slug, bio, avatar, links, email and
+payout details all replaced — a row left sitting there with somebody's name and
+payout account in it is not deletion.
+
+**Apple subscriptions are not cancelled by any of this**, because they belong to
+the Apple ID rather than to the Cabo account and nothing on our side can touch
+them. The confirmation screen says so in a warning block above the confirmation
+field, with a link to the App Store subscription settings, because finding that
+out from the next charge is how someone becomes justifiably angry — and is an
+App Review risk in its own right.
+
+`get_coach_roster()` and `get_my_coaches()` both `LEFT JOIN creator_profiles`
+and are unaffected; `coach_profiles.subscriber_count` stays honest because the
+`AFTER DELETE` trigger on `coach_subscriptions` recomputes it per row.
+`account-deletion-probe.mjs` asserts all of that, and that the photo object is
+genuinely gone from the bucket.
+
 ### Conversations
 
 `conversations` (one per user/coach/channel) and `conversation_messages`
@@ -166,6 +216,7 @@ access.
 | `20260811120000_service_role_grants_for_legacy_tables.sql` | Explicit `service_role` DML on `user_profiles` / `subscriptions`, which the SMS job reads with the service key |
 | `20260811120100_creator_self_signup.sql` | INSERT guard on the platform-owned creator columns, one profile per account, `creator_slug_available`, coach attribution guard |
 | `20260811120200_prompt_v2_rollout.sql` | Moves every coach to prompt v2, logging previous values so the rollout is exactly reversible |
+| `20260812090000_account_deletion.sql` | `coach_profiles`' two owner foreign keys stop cascading; `delete_member_account()` |
 
 All of them are idempotent and verified by applying the full migration chain
 from scratch against Postgres 16 + pgvector.
@@ -189,6 +240,14 @@ instructor. It is a seed, not a migration — run it by hand on dev/staging.
   to read their own split. Splitting the two needs a view or a definer function.
 - **Revenue split is recorded, not paid.** `revenue_share_bps` is stored; there
   is no payout job.
+- **The coach detail read fails for `anon`.** Selecting `coach_profiles` with
+  embedded joins returns `permission denied for table user_profiles`, because
+  the legacy phone-era policies (`Users can view their own coaches`) subquery
+  `user_profiles` directly instead of going through the `SECURITY DEFINER`
+  `owns_coach()`, and `anon` has no grant on that table. Reproducible on `main`
+  and visible as four failures in `rls-probe.mjs`; the fix is to rewrite those
+  three policies in terms of `owns_coach()`, which is what the newer `by uid`
+  policies already do.
 - **SMS members have no way to give likeness consent.** The daily image now
   honours `likeness_consent` strictly, and nothing in the SMS flow asks for it,
   so every SMS image renders scene-only until that is wired up.

--- a/functions/account-deletion/index.js
+++ b/functions/account-deletion/index.js
@@ -1,0 +1,226 @@
+/**
+ * Deletes a member's account, for real.
+ *
+ *   POST /preview   {}                     -> what deleting would destroy
+ *   POST /          { confirm: "DELETE" }  -> destroys it
+ *
+ * Both require a Supabase JWT, and the only account this can delete is the one
+ * that JWT belongs to. There is no id parameter: an endpoint that takes a user
+ * id is one authorization bug away from letting anybody delete anybody.
+ *
+ * App Store Review Guideline 5.1.1(v) is why this exists, but the shape is
+ * driven by what is actually stored. `member_goals` holds what someone is
+ * struggling with, `conversation_messages` holds every word they have said to a
+ * coach, and `user_profiles.reference_photo_url` points at a photograph of
+ * their face. So the order is deliberate:
+ *
+ *   1. delete the reference photo objects from the member-media bucket
+ *   2. delete every public-schema row (`delete_member_account`, one transaction)
+ *   3. delete the auth.users row through GoTrue's admin API
+ *
+ * The photo goes first for the same reason `coach-visualizer`'s likeness
+ * revocation deletes it first: a pointer cleared while the object survives is
+ * not an erasure, and once the row is gone nothing knows the object is there.
+ * If step 1 cannot be completed we stop before step 2 — an orphaned photograph
+ * of somebody who no longer has an account is the one outcome worse than a
+ * failed deletion, and the member can retry.
+ *
+ * What this does NOT do, and says so in the app before the member commits:
+ * cancel their Apple subscriptions. Those are held by Apple against their Apple
+ * ID, not by us, and nothing we can call from here touches them.
+ */
+
+const { createClient } = require('@supabase/supabase-js');
+const { Storage } = require('@google-cloud/storage');
+const { z } = require('zod');
+const { deleteReferencePhotos, referencePrefix } = require('./reference-photo');
+
+const supabase = createClient(
+  process.env.SUPABASE_URL,
+  process.env.SUPABASE_SERVICE_ROLE_KEY
+);
+const storage = new Storage();
+
+const PROJECT_ID = process.env.PROJECT_ID || process.env.GOOGLE_CLOUD_PROJECT;
+const MEMBER_MEDIA_BUCKET = process.env.MEMBER_MEDIA_BUCKET || `${PROJECT_ID}-member-media`;
+
+/*
+  Not a boolean, and not optional. The client has to send the same word the
+  member typed, so a malformed or replayed request cannot delete an account and
+  neither can a stray `{}` from a retry.
+*/
+const DeleteRequest = z.object({
+  confirm: z.literal('DELETE'),
+});
+
+async function resolveCaller(req) {
+  const header = req.get('authorization') || '';
+  const token = header.startsWith('Bearer ') ? header.slice(7).trim() : null;
+  if (!token) return null;
+  const { data, error } = await supabase.auth.getUser(token);
+  if (error || !data?.user) return null;
+  return data.user;
+}
+
+/**
+ * What the confirmation screen shows: counts, in the member's own terms, read
+ * live rather than guessed at. Best effort — a count that fails to load must
+ * not block someone from deleting their account.
+ */
+async function handlePreview(req, res) {
+  const caller = await resolveCaller(req);
+  if (!caller) return res.status(401).json({ error: 'Authentication required' });
+
+  const count = async (table) => {
+    const { count: n, error } = await supabase
+      .from(table)
+      .select('id', { count: 'exact', head: true })
+      .eq('user_id', caller.id);
+    return error ? null : n ?? 0;
+  };
+
+  const [conversations, goals, images, subscriptions] = await Promise.all([
+    count('conversations'),
+    count('member_goals'),
+    count('coach_visualizations'),
+    count('coach_subscriptions'),
+  ]);
+
+  const { data: profile } = await supabase
+    .from('user_profiles')
+    .select('reference_photo_url')
+    .eq('user_id', caller.id)
+    .maybeSingle();
+
+  return res.json({
+    success: true,
+    summary: {
+      conversations,
+      goals,
+      images,
+      subscriptions,
+      hasReferencePhoto: Boolean(profile?.reference_photo_url),
+    },
+  });
+}
+
+/**
+ * Sweep the member's whole prefix in the member-media bucket.
+ *
+ * By prefix rather than by the URI in `reference_photo_url`, exactly as
+ * revocation does: a photo stored under an older extension, or one orphaned by
+ * a grant that failed halfway, is still a photograph of this person's face and
+ * must not survive them deleting their account.
+ *
+ * One retry, because the common failure here is a transient 5xx from GCS and
+ * making somebody ask twice to be deleted is a bad experience for no reason.
+ */
+async function purgeMemberMedia(userId) {
+  const attempt = () =>
+    deleteReferencePhotos({ storage, bucketName: MEMBER_MEDIA_BUCKET, userId });
+
+  try {
+    return await attempt();
+  } catch (error) {
+    console.warn('Member media sweep failed, retrying once:', error.message);
+    return attempt();
+  }
+}
+
+async function handleDelete(req, res) {
+  const caller = await resolveCaller(req);
+  if (!caller) return res.status(401).json({ error: 'Authentication required' });
+
+  DeleteRequest.parse(req.body || {});
+
+  // 1. The photograph, first.
+  let photosDeleted;
+  try {
+    photosDeleted = await purgeMemberMedia(caller.id);
+  } catch (error) {
+    console.error('Could not delete member media; aborting deletion:', error.message);
+    return res.status(503).json({
+      error: 'media_delete_failed',
+      message:
+        'We could not delete your stored photo just now, and we will not delete your ' +
+        'account while a photo of you is still stored. Please try again in a few minutes.',
+    });
+  }
+
+  // 2. Everything in the database, in one transaction.
+  const { data: summary, error: rpcError } = await supabase.rpc('delete_member_account', {
+    p_user_id: caller.id,
+  });
+
+  if (rpcError) {
+    console.error('delete_member_account failed:', rpcError);
+    return res.status(500).json({
+      error: 'account_delete_failed',
+      message: 'We could not delete your account just now. Please try again in a moment.',
+    });
+  }
+
+  // 3. The identity itself. GoTrue's admin API rather than a DELETE on
+  //    auth.users, so identities, sessions and refresh tokens go with it and
+  //    the current access token stops working.
+  const { error: authError } = await supabase.auth.admin.deleteUser(caller.id);
+
+  if (authError) {
+    /*
+      Their data is already gone, so this is not a partial deletion in any sense
+      the member would care about — but the login would still work and would
+      hand them a blank account they did not ask for. Say it failed and let them
+      retry; step 2 is a no-op the second time.
+    */
+    console.error('auth.users delete failed after data removal:', authError);
+    return res.status(500).json({
+      error: 'account_delete_failed',
+      message: 'We removed your data but could not finish closing your account. Please try again.',
+    });
+  }
+
+  console.log(
+    'Account deleted: user=%s photos=%d summary=%j',
+    caller.id,
+    photosDeleted,
+    summary
+  );
+
+  return res.json({
+    success: true,
+    photosDeleted,
+    prefix: referencePrefix(caller.id),
+    summary,
+  });
+}
+
+exports.deleteAccount = async (req, res) => {
+  res.set('Access-Control-Allow-Origin', process.env.ALLOWED_ORIGINS || '*');
+  res.set('Access-Control-Allow-Methods', 'POST, OPTIONS');
+  res.set('Access-Control-Allow-Headers', 'Content-Type, Authorization');
+
+  if (req.method === 'OPTIONS') return res.status(204).send('');
+  if (req.method !== 'POST') return res.status(405).json({ error: 'Method not allowed' });
+
+  const path = (req.path || '/').replace(/\/+$/, '') || '/';
+
+  try {
+    if (path.endsWith('/preview')) return await handlePreview(req, res);
+    return await handleDelete(req, res);
+  } catch (error) {
+    if (error instanceof z.ZodError) {
+      // Reaching this means the client sent something other than the typed
+      // confirmation; it is a bug in the client, not something to retry.
+      return res.status(400).json({
+        error: 'confirmation_required',
+        message: 'Deleting an account has to be confirmed explicitly.',
+      });
+    }
+
+    console.error('account-deletion error:', error);
+    return res.status(500).json({
+      error: 'account_delete_failed',
+      message: 'We could not delete your account just now. Please try again in a moment.',
+    });
+  }
+};

--- a/functions/account-deletion/package-lock.json
+++ b/functions/account-deletion/package-lock.json
@@ -1,0 +1,1158 @@
+{
+  "name": "account-deletion",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "account-deletion",
+      "version": "1.0.0",
+      "dependencies": {
+        "@google-cloud/storage": "^7.15.1",
+        "@supabase/supabase-js": "^2.47.0",
+        "zod": "^3.24.1"
+      }
+    },
+    "node_modules/@google-cloud/paginator": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@google-cloud/paginator/-/paginator-5.0.2.tgz",
+      "integrity": "sha512-DJS3s0OVH4zFDB1PzjxAsHqJT6sKVbRwwML0ZBP9PbU7Yebtu/7SWMRzvO2J3nUi9pRNITCfu4LJeooM2w4pjg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "arrify": "^2.0.0",
+        "extend": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@google-cloud/projectify": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@google-cloud/projectify/-/projectify-4.0.0.tgz",
+      "integrity": "sha512-MmaX6HeSvyPbWGwFq7mXdo0uQZLGBYCwziiLIGq5JVX+/bdI3SAq6bP98trV5eTWfLuvsMcIC1YJOF2vfteLFA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@google-cloud/promisify": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@google-cloud/promisify/-/promisify-4.0.0.tgz",
+      "integrity": "sha512-Orxzlfb9c67A15cq2JQEyVc7wEsmFBmHjZWZYQMUyJ1qivXyMwdyNOs9odi79hze+2zqdTtu1E19IM/FtqZ10g==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@google-cloud/storage": {
+      "version": "7.22.0",
+      "resolved": "https://registry.npmjs.org/@google-cloud/storage/-/storage-7.22.0.tgz",
+      "integrity": "sha512-W98gTQOAntEeEQ7/pZxSQXxfUO5CiQcXJRsxBpUa6UU25n8YN/VtogPBi0H+MAmUrn/6bY/sBhFansoWEsr2/g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@google-cloud/paginator": "^5.0.0",
+        "@google-cloud/projectify": "^4.0.0",
+        "@google-cloud/promisify": "<4.1.0",
+        "abort-controller": "^3.0.0",
+        "async-retry": "^1.3.3",
+        "duplexify": "^4.1.3",
+        "fast-xml-parser": "^5.3.4",
+        "gaxios": "^6.0.2",
+        "google-auth-library": "^9.6.3",
+        "html-entities": "^2.5.2",
+        "mime": "^3.0.0",
+        "p-limit": "^3.0.1",
+        "retry-request": "^7.0.0",
+        "teeny-request": "^9.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@nodable/entities": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-3.0.0.tgz",
+      "integrity": "sha512-8L9xFeTYKhm49xfIypoe2W5wV1m/3Z58kT+7kR9A8OyFxcPduI4VmxaUMQyKYrRjUoLLSXv6EKKID5Tvj9cUVw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodable"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/@supabase/auth-js": {
+      "version": "2.112.3",
+      "resolved": "https://registry.npmjs.org/@supabase/auth-js/-/auth-js-2.112.3.tgz",
+      "integrity": "sha512-NA0rsgAlWZPvbhw8aUdmgfpHVgUAcd8zK5ov43l++o1bLIPXZhRiAlRobhwF5AatQuovpqxsMH50F4oyyV4XZw==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    },
+    "node_modules/@supabase/functions-js": {
+      "version": "2.112.3",
+      "resolved": "https://registry.npmjs.org/@supabase/functions-js/-/functions-js-2.112.3.tgz",
+      "integrity": "sha512-gfv481mTOVWtZIJgXupxZpni2V2UWPf6jeF/jOK7HdMHdH+mt6sU0sHHwf0POsPip8ltlulu9OUHgwVzl5ddRw==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    },
+    "node_modules/@supabase/phoenix": {
+      "version": "0.4.5",
+      "resolved": "https://registry.npmjs.org/@supabase/phoenix/-/phoenix-0.4.5.tgz",
+      "integrity": "sha512-aAn9H9ovVyeApKy11OWOrrOGq8DV68yWeH4ud2lN9fzn4aO8Zb5GLL9m1pUg9nLqIcT+ZDfAcsZe0E/nqdv2lw==",
+      "license": "MIT"
+    },
+    "node_modules/@supabase/postgrest-js": {
+      "version": "2.112.3",
+      "resolved": "https://registry.npmjs.org/@supabase/postgrest-js/-/postgrest-js-2.112.3.tgz",
+      "integrity": "sha512-+Mf6uCpzr00bqxwX8hTK2X2L9eAL/1vuOjdEjx6upz9ulb0RmQT16XeU/JkMUlVHw/B46ZnPa2busY4Kd9YCzw==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    },
+    "node_modules/@supabase/realtime-js": {
+      "version": "2.112.3",
+      "resolved": "https://registry.npmjs.org/@supabase/realtime-js/-/realtime-js-2.112.3.tgz",
+      "integrity": "sha512-E6wljXWs7DUOloyIB69i3YFInWE6IyCvgTAbQ0KYxOHv26FdA1KzEXTuzxrYEdf70t406Z9BRwUlGyclGF2FXA==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/phoenix": "0.4.5",
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    },
+    "node_modules/@supabase/storage-js": {
+      "version": "2.112.3",
+      "resolved": "https://registry.npmjs.org/@supabase/storage-js/-/storage-js-2.112.3.tgz",
+      "integrity": "sha512-oSK61tzlUvg+BWPqpKQCu9qqonsO26btaoAR9D6Gest2aj7xUqToj9rKyaoYOJczkhg9BjqA1REbYy9tPI4bDA==",
+      "license": "MIT",
+      "dependencies": {
+        "iceberg-js": "^0.8.1",
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    },
+    "node_modules/@supabase/supabase-js": {
+      "version": "2.112.3",
+      "resolved": "https://registry.npmjs.org/@supabase/supabase-js/-/supabase-js-2.112.3.tgz",
+      "integrity": "sha512-Jv1bxVQmEJNkjvPEhFaKjPzsh+Ozyew6lWGD+SoYcsclDEP1z7yEvKvfUQfzy0DkxRIQnZNxmmWtAzw5XLTQoA==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/auth-js": "2.112.3",
+        "@supabase/functions-js": "2.112.3",
+        "@supabase/postgrest-js": "2.112.3",
+        "@supabase/realtime-js": "2.112.3",
+        "@supabase/storage-js": "2.112.3"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@opentelemetry/api": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@tootallnate/once": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.1.tgz",
+      "integrity": "sha512-HqmEUIGRJ5fSXchkVgR5F7qn48bDBzv0kWj/Kfu5e6uci4UlEeng4331LnBkWffb++Ei3FOVLxo8JJWMFBDMeQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@types/caseless": {
+      "version": "0.12.5",
+      "resolved": "https://registry.npmjs.org/@types/caseless/-/caseless-0.12.5.tgz",
+      "integrity": "sha512-hWtVTC2q7hc7xZ/RLbxapMvDMgUnDvKvMOpKal4DrMyfGBUfB1oKaZlIRr6mJL+If3bAP6sV/QneGzF6tJjZDg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "26.2.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.2.0.tgz",
+      "integrity": "sha512-5IviulTZeRNp2vAJ514cc/HUlY5nZ9fCbq9DMyC52BrhFZACo3nI0R7qBxhQmo/d27NFe96ur/b7Wwxklda+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~8.3.0"
+      }
+    },
+    "node_modules/@types/request": {
+      "version": "2.48.13",
+      "resolved": "https://registry.npmjs.org/@types/request/-/request-2.48.13.tgz",
+      "integrity": "sha512-FGJ6udDNUCjd19pp0Q3iTiDkwhYup7J8hpMW9c4k53NrccQFFWKRho6hvtPPEhnXWKvukfwAlB6DbDz4yhH5Gg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/caseless": "*",
+        "@types/node": "*",
+        "@types/tough-cookie": "*",
+        "form-data": "^2.5.5"
+      }
+    },
+    "node_modules/@types/tough-cookie": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.5.tgz",
+      "integrity": "sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==",
+      "license": "MIT"
+    },
+    "node_modules/abort-controller": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
+      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
+      "license": "MIT",
+      "dependencies": {
+        "event-target-shim": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=6.5"
+      }
+    },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/anynum": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/anynum/-/anynum-1.0.1.tgz",
+      "integrity": "sha512-N6//FLET/tXYNM/F6ABca1oH6fWB+KlTt909Le28WMDBk8oaT4vY17DCrwg2MvmuqUKt3Ni4N5dGJ/EoBgcO6A==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/arrify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/arrify/-/arrify-2.0.1.tgz",
+      "integrity": "sha512-3duEwti880xqi4eAMN8AyR4a0ByT90zoYdLlevfrvU43vb0YZwZVfxOgxWrLXXXpyugL0hNZc9G6BiB5B3nUug==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/async-retry": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/async-retry/-/async-retry-1.3.3.tgz",
+      "integrity": "sha512-wfr/jstw9xNi/0teMHrRW7dsz3Lt5ARhYNZ2ewpadnhaIp5mbALhOAP+EAdsC7t4Z6wqsDVv9+W6gm1Dk9mEyw==",
+      "license": "MIT",
+      "dependencies": {
+        "retry": "0.13.1"
+      }
+    },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "license": "MIT"
+    },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/bignumber.js": {
+      "version": "9.3.1",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.3.1.tgz",
+      "integrity": "sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/duplexify": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-4.1.3.tgz",
+      "integrity": "sha512-M3BmBhwJRZsSx38lZyhE53Csddgzl5R7xGJNk7CVddZD6CcmwMCH8J+7AprIrQKH7TonKxaCjcv27Qmf+sQ+oA==",
+      "license": "MIT",
+      "dependencies": {
+        "end-of-stream": "^1.4.1",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1",
+        "stream-shift": "^1.0.2"
+      }
+    },
+    "node_modules/ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/end-of-stream": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+      "license": "MIT",
+      "dependencies": {
+        "once": "^1.4.0"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/event-target-shim": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
+      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/extend": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+      "license": "MIT"
+    },
+    "node_modules/fast-xml-builder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.3.0.tgz",
+      "integrity": "sha512-F74cZEdCvuw9P41GAC3rod4X04jjWGM1JPEv/GWSqFTWLsdyMSBMBMlm9Hk3GLBgLBbdBNY8yee0pQh2RBVESQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "path-expression-matcher": "^1.6.2",
+        "xml-naming": "^0.3.0"
+      }
+    },
+    "node_modules/fast-xml-parser": {
+      "version": "5.10.1",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.10.1.tgz",
+      "integrity": "sha512-IEMIf7298kXuZSRFoGfMYrl7is8LpavODgbNz1cwIudv7KwVFnuU+UsMporfq6PD6aXSlawZlARiA3UywCTfMw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@nodable/entities": "^3.0.0",
+        "fast-xml-builder": "^1.2.0",
+        "is-unsafe": "^2.0.0",
+        "path-expression-matcher": "^1.6.2",
+        "strnum": "^2.4.1",
+        "xml-naming": "^0.3.0"
+      },
+      "bin": {
+        "fxparser": "src/cli/cli.js"
+      }
+    },
+    "node_modules/form-data": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.5.6.tgz",
+      "integrity": "sha512-Ogz/E85h9tlfJzpI6TuFpGcHZFhLrb9Gw8wq9v40CxSCPnv7ahKr6Xgtkn0KYCDQJ8DNn5VoMO8EXr9V5PadyA==",
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.4",
+        "mime-types": "^2.1.35",
+        "safe-buffer": "^5.2.1"
+      },
+      "engines": {
+        "node": ">= 0.12"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/gaxios": {
+      "version": "6.7.1",
+      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-6.7.1.tgz",
+      "integrity": "sha512-LDODD4TMYx7XXdpwxAVRAIAuB0bzv0s+ywFonY46k126qzQHT9ygyoa9tncmOiQmmDrik65UYsEkv3lbfqQ3yQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "extend": "^3.0.2",
+        "https-proxy-agent": "^7.0.1",
+        "is-stream": "^2.0.0",
+        "node-fetch": "^2.6.9",
+        "uuid": "^9.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/gcp-metadata": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-6.1.1.tgz",
+      "integrity": "sha512-a4tiq7E0/5fTjxPAaH4jpjkSv/uCaU2p5KC6HVGrvl0cDjA8iBZv4vv1gyzlmK0ZUKqwpOyQMKzZQe3lTit77A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "gaxios": "^6.1.1",
+        "google-logging-utils": "^0.0.2",
+        "json-bigint": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/google-auth-library": {
+      "version": "9.15.1",
+      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-9.15.1.tgz",
+      "integrity": "sha512-Jb6Z0+nvECVz+2lzSMt9u98UsoakXxA2HGHMCxh+so3n90XgYWkq5dur19JAJV7ONiJY22yBTyJB1TSkvPq9Ng==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "base64-js": "^1.3.0",
+        "ecdsa-sig-formatter": "^1.0.11",
+        "gaxios": "^6.1.1",
+        "gcp-metadata": "^6.1.0",
+        "gtoken": "^7.0.0",
+        "jws": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/google-logging-utils": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/google-logging-utils/-/google-logging-utils-0.0.2.tgz",
+      "integrity": "sha512-NEgUnEcBiP5HrPzufUkBzJOD/Sxsco3rLNo1F1TNf7ieU8ryUzBhqba8r756CjLX7rn3fHl6iLEwPYuqpoKgQQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/gtoken": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/gtoken/-/gtoken-7.1.0.tgz",
+      "integrity": "sha512-pCcEwRi+TKpMlxAQObHDQ56KawURgyAf6jtIY046fJ5tIv3zDe/LEIubckAO8fj6JnAxLdmWkUfNyulQ2iKdEw==",
+      "license": "MIT",
+      "dependencies": {
+        "gaxios": "^6.0.0",
+        "jws": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/html-entities": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/html-entities/-/html-entities-2.6.0.tgz",
+      "integrity": "sha512-kig+rMn/QOVRvr7c86gQ8lWXq+Hkv6CbAH1hLu+RG338StTpE8Z0b44SDVaqVu7HGKf27frdmUYEs9hTUX/cLQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/mdevils"
+        },
+        {
+          "type": "patreon",
+          "url": "https://patreon.com/mdevils"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/http-proxy-agent": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-5.0.0.tgz",
+      "integrity": "sha512-n2hY8YdoRE1i7r6M0w9DIw5GgZN0G25P8zLCRQ8rjXtTU3vsNFBI/vWK/UIeE6g5MUUz6avwAPXmL6Fy9D/90w==",
+      "license": "MIT",
+      "dependencies": {
+        "@tootallnate/once": "2",
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/http-proxy-agent/node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/iceberg-js": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/iceberg-js/-/iceberg-js-0.8.1.tgz",
+      "integrity": "sha512-1dhVQZXhcHje7798IVM+xoo/1ZdVfzOMIc8/rgVSijRK38EDqOJoGula9N/8ZI5RD8QTxNQtK/Gozpr+qUqRRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/is-stream": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+      "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-unsafe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-unsafe/-/is-unsafe-2.0.0.tgz",
+      "integrity": "sha512-2LdV822R+wmI86unXA93WCFpL6g+av8ynWk0nrHyJqGop5VoocYsSLFgN8jrfalT6iGeLNM4KXuVSsULP53kEA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/json-bigint": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-bigint/-/json-bigint-1.0.0.tgz",
+      "integrity": "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "bignumber.js": "^9.0.0"
+      }
+    },
+    "node_modules/jwa": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
+      "integrity": "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-equal-constant-time": "^1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/jws": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.1.tgz",
+      "integrity": "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==",
+      "license": "MIT",
+      "dependencies": {
+        "jwa": "^2.0.1",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/mime": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-3.0.0.tgz",
+      "integrity": "sha512-jSCU7/VB1loIWBZe14aEYHU/+1UMEHoaO7qxCOVJOw9GgH72VAWppxNcjU+x9a2k3GSIBXNKxXQFqRvvZ7vr3A==",
+      "license": "MIT",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/p-limit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "license": "MIT",
+      "dependencies": {
+        "yocto-queue": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/path-expression-matcher": {
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.6.2.tgz",
+      "integrity": "sha512-enSlaiat05iasnzmgNxRj8reFdj3puY2QpNgP1aPIaVfT6nn9ICuPoFlKHk8EN22HcwewshO+mN2DGbkCEOtqQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/retry": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
+      "integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/retry-request": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/retry-request/-/retry-request-7.0.2.tgz",
+      "integrity": "sha512-dUOvLMJ0/JJYEn8NrpOaGNE7X3vpI5XlZS/u0ANjqtcZVKnIxP7IgCFwrKTxENw29emmwug53awKtaMm4i9g5w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/request": "^2.48.8",
+        "extend": "^3.0.2",
+        "teeny-request": "^9.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/stream-events": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/stream-events/-/stream-events-1.0.5.tgz",
+      "integrity": "sha512-E1GUzBSgvct8Jsb3v2X15pjzN1tYebtbLaMg+eBOUOAxgbLoSbT2NS91ckc5lJD1KfLjId+jXJRgo0qnV5Nerg==",
+      "license": "MIT",
+      "dependencies": {
+        "stubs": "^3.0.0"
+      }
+    },
+    "node_modules/stream-shift": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.3.tgz",
+      "integrity": "sha512-76ORR0DO1o1hlKwTbi/DM3EXWGf3ZJYO8cXX5RJwnul2DEg2oyoZyjLNoQM8WsvZiFKCRfC1O0J7iCvie3RZmQ==",
+      "license": "MIT"
+    },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
+    "node_modules/strnum": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.4.1.tgz",
+      "integrity": "sha512-M9eUSMT2dCB2cTNPG7UYj6KuK7RJR2SN2+yCV/fTW3xzTCS6EaGZ5pSMgDIjB7r8zSfTGk+dvvn9rTjpVS9Mwg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "anynum": "^1.0.1"
+      }
+    },
+    "node_modules/stubs": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/stubs/-/stubs-3.0.0.tgz",
+      "integrity": "sha512-PdHt7hHUJKxvTCgbKX9C1V/ftOcjJQgz8BZwNfV5c4B6dcGqlpelTbJ999jBGZ2jYiPAwcX5dP6oBwVlBlUbxw==",
+      "license": "MIT"
+    },
+    "node_modules/teeny-request": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/teeny-request/-/teeny-request-9.0.0.tgz",
+      "integrity": "sha512-resvxdc6Mgb7YEThw6G6bExlXKkv6+YbuzGg9xuXxSgxJF7Ozs+o8Y9+2R3sArdWdW8nOokoQb1yrpFB0pQK2g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "http-proxy-agent": "^5.0.0",
+        "https-proxy-agent": "^5.0.0",
+        "node-fetch": "^2.6.9",
+        "stream-events": "^1.0.5",
+        "uuid": "^9.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/teeny-request/node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/teeny-request/node_modules/https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "license": "MIT"
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/undici-types": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
+      "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
+      "license": "MIT"
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "license": "MIT"
+    },
+    "node_modules/uuid": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC"
+    },
+    "node_modules/xml-naming": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/xml-naming/-/xml-naming-0.3.0.tgz",
+      "integrity": "sha512-ghig2TBE/H11aOVgmahA3MhimvkBr6JIYknH/Dhdk10nXwdbIqBJsbfMxpvFPG8bAw77gN29aQWvKpmVoPlvPQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    }
+  }
+}

--- a/functions/account-deletion/package.json
+++ b/functions/account-deletion/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "account-deletion",
+  "version": "1.0.0",
+  "dependencies": {
+    "@google-cloud/storage": "^7.15.1",
+    "@supabase/supabase-js": "^2.47.0",
+    "zod": "^3.24.1"
+  }
+}

--- a/functions/account-deletion/reference-photo.js
+++ b/functions/account-deletion/reference-photo.js
@@ -1,0 +1,179 @@
+/**
+ * The member's reference photo.
+ *
+ * PhotoMaker can only keep someone's face if it has a picture of that face, so
+ * this is the one place in the product that stores a photograph of a member.
+ * That makes it biometric-adjacent, and everything here is shaped by two rules:
+ *
+ *   1. The file is never public. It lives in a private bucket and is handed to
+ *      the image model as a signed URL that expires in minutes, so a leaked
+ *      link is worthless within the hour and worthless immediately once the
+ *      object is gone.
+ *   2. Withdrawing consent deletes the file. Not a flag, not a lifecycle rule
+ *      a week later — the object. `deleteReferencePhotos` sweeps the whole
+ *      per-member prefix rather than the single path we think we wrote, so a
+ *      photo stored under an older extension cannot survive a revocation.
+ *
+ * Storage layout mirrors `coach-avatar-generator`'s selfie handling (private
+ * object + v4 signed URL for the model to fetch), one prefix per member:
+ *
+ *   member-reference/<user id>/reference.<ext>
+ */
+
+const MAX_PHOTO_BYTES = 6 * 1024 * 1024;
+
+/** What PhotoMaker can actually read. HEIC is rejected with a clear message. */
+const ALLOWED_MIME_TYPES = {
+  'image/jpeg': 'jpg',
+  'image/png': 'png',
+  'image/webp': 'webp',
+};
+
+/**
+ * Short by design: it only has to survive one `replicate.run` call, and a short
+ * window is the difference between "revoked" and "revoked, mostly".
+ */
+const SIGNED_URL_TTL_MS = 15 * 60 * 1000;
+
+class InvalidPhotoError extends Error {
+  constructor(code, message) {
+    super(message);
+    this.name = 'InvalidPhotoError';
+    this.code = code;
+  }
+}
+
+const referencePrefix = (userId) => `member-reference/${userId}/`;
+const referenceObjectName = (userId, mime) =>
+  `${referencePrefix(userId)}reference.${ALLOWED_MIME_TYPES[mime]}`;
+
+function parseGsUri(uri) {
+  if (typeof uri !== 'string') return null;
+  const match = uri.match(/^gs:\/\/([^/]+)\/(.+)$/);
+  return match ? { bucket: match[1], name: match[2] } : null;
+}
+
+/**
+ * Trust the bytes, not the client's content type — an `image/jpeg` label on a
+ * PDF should not end up in the bucket, and a HEIC mislabelled as JPEG would
+ * fail deep inside the model with an unreadable error instead of here.
+ */
+function sniffImageType(buffer) {
+  if (buffer.length < 12) return null;
+  if (buffer[0] === 0xff && buffer[1] === 0xd8 && buffer[2] === 0xff) return 'image/jpeg';
+  if (buffer.subarray(0, 8).equals(Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]))) {
+    return 'image/png';
+  }
+  if (buffer.subarray(0, 4).toString('ascii') === 'RIFF' &&
+      buffer.subarray(8, 12).toString('ascii') === 'WEBP') {
+    return 'image/webp';
+  }
+  if (buffer.subarray(4, 8).toString('ascii') === 'ftyp') {
+    const brand = buffer.subarray(8, 12).toString('ascii');
+    if (/^(heic|heix|hevc|heim|heis|hevm|mif1|msf1)$/.test(brand)) return 'image/heic';
+  }
+  return null;
+}
+
+/**
+ * Decode what the app sent into bytes we are willing to store.
+ * Throws `InvalidPhotoError` with a message written for the member.
+ */
+function decodeReferencePhoto({ photoBase64 }) {
+  const payload = String(photoBase64 || '').replace(/^data:[^;]+;base64,/, '');
+  if (!payload) {
+    throw new InvalidPhotoError('photo_missing', 'No photo was included.');
+  }
+
+  // Guard before allocating: base64 is ~4/3 of the decoded size.
+  if (payload.length > MAX_PHOTO_BYTES * 1.4) {
+    throw new InvalidPhotoError('photo_too_large', 'That photo is too large. Please pick one under 6MB.');
+  }
+
+  const buffer = Buffer.from(payload, 'base64');
+  if (buffer.length === 0) {
+    throw new InvalidPhotoError('photo_unreadable', 'That photo could not be read. Please try another.');
+  }
+  if (buffer.length > MAX_PHOTO_BYTES) {
+    throw new InvalidPhotoError('photo_too_large', 'That photo is too large. Please pick one under 6MB.');
+  }
+
+  const detected = sniffImageType(buffer);
+  if (detected === 'image/heic') {
+    throw new InvalidPhotoError(
+      'photo_unsupported_format',
+      'That photo is in Apple\'s HEIC format. Crop it in Photos first, or pick a JPEG.'
+    );
+  }
+  if (!detected || !ALLOWED_MIME_TYPES[detected]) {
+    throw new InvalidPhotoError(
+      'photo_unsupported_format',
+      'That file is not a JPEG, PNG or WebP image.'
+    );
+  }
+
+  return { buffer, mime: detected };
+}
+
+async function storeReferencePhoto({ storage, bucketName, userId, buffer, mime }) {
+  // Replacing a photo must not leave the old one behind under a different
+  // extension, so clear the prefix before writing.
+  await deleteReferencePhotos({ storage, bucketName, userId });
+
+  const name = referenceObjectName(userId, mime);
+  await storage.bucket(bucketName).file(name).save(buffer, {
+    contentType: mime,
+    resumable: false,
+    metadata: { cacheControl: 'private, no-store' },
+  });
+
+  return { uri: `gs://${bucketName}/${name}`, name };
+}
+
+/**
+ * Delete every object stored for this member. Returns how many were removed.
+ * Throws if the delete fails — the caller decides what to tell the member, but
+ * it must never be reported as a successful erasure.
+ */
+async function deleteReferencePhotos({ storage, bucketName, userId }) {
+  const [files] = await storage.bucket(bucketName).getFiles({ prefix: referencePrefix(userId) });
+  await Promise.all(files.map((file) => file.delete({ ignoreNotFound: true })));
+  return files.length;
+}
+
+/** True only if the object is really still there. */
+async function referencePhotoExists({ storage, uri }) {
+  const location = parseGsUri(uri);
+  if (!location) return false;
+  const [exists] = await storage.bucket(location.bucket).file(location.name).exists();
+  return exists;
+}
+
+/** A read URL the image model can fetch, valid for minutes rather than days. */
+async function signReferencePhoto({ storage, uri, ttlMs = SIGNED_URL_TTL_MS }) {
+  const location = parseGsUri(uri);
+  if (!location) return null;
+
+  const [signedUrl] = await storage
+    .bucket(location.bucket)
+    .file(location.name)
+    .getSignedUrl({ version: 'v4', action: 'read', expires: Date.now() + ttlMs });
+
+  return signedUrl;
+}
+
+module.exports = {
+  ALLOWED_MIME_TYPES,
+  MAX_PHOTO_BYTES,
+  SIGNED_URL_TTL_MS,
+  InvalidPhotoError,
+  decodeReferencePhoto,
+  deleteReferencePhotos,
+  parseGsUri,
+  referenceObjectName,
+  referencePrefix,
+  referencePhotoExists,
+  signReferencePhoto,
+  sniffImageType,
+  storeReferencePhoto,
+};

--- a/mobile/app/(tabs)/settings.tsx
+++ b/mobile/app/(tabs)/settings.tsx
@@ -38,8 +38,18 @@ export default function SettingsScreen() {
   return (
     <Screen edges={[]}>
       <ScrollView contentContainerStyle={styles.container}>
+        {/*
+          Delete lives at the top, with the account it deletes. Guideline
+          5.1.1(v) wants it findable, and burying it three screens down under
+          "Advanced" is the pattern the guideline exists to stop.
+        */}
         <Section title="Account">
           <Row label="Signed in as" value={user?.email ?? 'Apple ID'} />
+          <Action
+            label="Delete account"
+            destructive
+            onPress={() => router.push('/delete-account')}
+          />
         </Section>
 
         <Section title="Notifications">
@@ -138,10 +148,12 @@ function Action({
   label,
   onPress,
   disabled,
+  destructive,
 }: {
   label: string;
   onPress: () => void;
   disabled?: boolean;
+  destructive?: boolean;
 }) {
   return (
     <Pressable
@@ -150,7 +162,7 @@ function Action({
       accessibilityRole="button"
       style={({ pressed }) => [styles.row, (pressed || disabled) && styles.pressed]}
     >
-      <Text style={styles.actionLabel}>{label}</Text>
+      <Text style={[styles.actionLabel, destructive && styles.destructiveLabel]}>{label}</Text>
       <Text style={styles.chevron}>›</Text>
     </Pressable>
   );
@@ -210,6 +222,9 @@ const styles = StyleSheet.create({
   actionLabel: {
     color: theme.color.text,
     fontSize: theme.font.body,
+  },
+  destructiveLabel: {
+    color: theme.color.danger,
   },
   chevron: {
     color: theme.color.textFaint,

--- a/mobile/app/_layout.tsx
+++ b/mobile/app/_layout.tsx
@@ -67,6 +67,7 @@ function RootNavigator() {
       <Stack.Screen name="visualize/[coachId]" options={{ title: 'Becoming' }} />
       <Stack.Screen name="notification-settings" options={{ title: 'Notifications' }} />
       <Stack.Screen name="likeness" options={{ title: 'Your photo' }} />
+      <Stack.Screen name="delete-account" options={{ title: 'Delete account' }} />
     </Stack>
   );
 }

--- a/mobile/app/delete-account.tsx
+++ b/mobile/app/delete-account.tsx
@@ -1,0 +1,304 @@
+/**
+ * Deleting your account.
+ *
+ * App Store Review Guideline 5.1.1(v) requires this to be reachable from inside
+ * the app, and specifically not a link out to a website. It is a full screen
+ * rather than an alert for two reasons: there is more to say than an alert can
+ * hold, and the thing that has to be said loudest — that we cannot cancel an
+ * Apple subscription for you — has to be read *before* the member commits, not
+ * discovered afterwards when the next charge lands.
+ *
+ * The gate is typing the word DELETE. A destructive, irreversible action should
+ * not be one mis-tap away, and a two-button alert is exactly one mis-tap.
+ */
+import React, { useEffect, useState } from 'react';
+import {
+  ActivityIndicator,
+  Alert,
+  Linking,
+  Pressable,
+  ScrollView,
+  StyleSheet,
+  Text,
+  TextInput,
+  View,
+} from 'react-native';
+import { useRouter } from 'expo-router';
+import { Screen } from '@/components/Screen';
+import { useAuth } from '@/contexts/AuthContext';
+import { deleteAccount, fetchDeletionSummary, type DeletionSummary } from '@/lib/api';
+import { unregisterThisDevice } from '@/lib/notifications';
+import { theme } from '@/lib/theme';
+
+const APPLE_SUBSCRIPTIONS_URL = 'https://apps.apple.com/account/subscriptions';
+const CONFIRMATION_WORD = 'DELETE';
+
+export default function DeleteAccountScreen() {
+  const router = useRouter();
+  const { signOut } = useAuth();
+
+  const [summary, setSummary] = useState<DeletionSummary | null>(null);
+  const [typed, setTyped] = useState('');
+  const [deleting, setDeleting] = useState(false);
+
+  useEffect(() => {
+    // Best effort. Not being able to count someone's conversations is no reason
+    // to stop them deleting their account.
+    fetchDeletionSummary()
+      .then(setSummary)
+      .catch(() => setSummary(null));
+  }, []);
+
+  const confirmed = typed.trim().toUpperCase() === CONFIRMATION_WORD;
+
+  async function handleDelete() {
+    if (!confirmed || deleting) return;
+    setDeleting(true);
+
+    try {
+      await deleteAccount();
+
+      // The account is gone; this device must stop receiving its coaches'
+      // notifications, and the stale session has to go before the router sends
+      // us back to sign-in.
+      await unregisterThisDevice().catch(() => {});
+      await signOut();
+
+      router.replace('/sign-in');
+      Alert.alert(
+        'Account deleted',
+        'Your account and everything in it is gone. If you had subscriptions, cancel them in the App Store so you are not charged again.'
+      );
+    } catch (error) {
+      Alert.alert('Could not delete your account', (error as Error).message ?? 'Please try again.');
+    } finally {
+      setDeleting(false);
+    }
+  }
+
+  return (
+    <Screen edges={['bottom']}>
+      <ScrollView contentContainerStyle={styles.content} keyboardShouldPersistTaps="handled">
+        <Text style={styles.lede}>
+          This deletes your account and everything in it, permanently. It cannot be undone and we
+          cannot get any of it back for you.
+        </Text>
+
+        <View style={styles.card}>
+          <Text style={styles.cardTitle}>What gets destroyed</Text>
+          <Bullet text="Every conversation with every coach, and every message in it" count={summary?.conversations} />
+          <Bullet text="The goals and obstacles you told your coaches about" count={summary?.goals} />
+          <Bullet text="Every picture your coaches made of you" count={summary?.images} />
+          <Bullet text="Your coach subscriptions and free-message allowances" count={summary?.subscriptions} />
+          <Bullet
+            text={
+              summary?.hasReferencePhoto
+                ? 'The photo of your face, deleted from storage and not recoverable'
+                : 'Any photo of you we hold, deleted from storage'
+            }
+          />
+          <Bullet text="Your profile, notification settings and registered devices" />
+        </View>
+
+        {/*
+          The single most important thing on this screen. An Apple subscription
+          belongs to the Apple ID, not to the Cabo account, and nothing we can
+          do from here cancels one. Someone who deletes their account and keeps
+          being billed is entitled to be furious about it.
+        */}
+        <View style={[styles.card, styles.warningCard]}>
+          <Text style={styles.warningTitle}>This does not cancel your subscriptions</Text>
+          <Text style={styles.warningBody}>
+            Coach subscriptions are billed by Apple against your Apple ID. Deleting your Cabo
+            account does not stop them and we cannot stop them for you — you will keep being
+            charged until you cancel them yourself in the App Store.
+          </Text>
+          <Pressable
+            accessibilityRole="button"
+            onPress={() => Linking.openURL(APPLE_SUBSCRIPTIONS_URL)}
+            style={({ pressed }) => [styles.warningLink, pressed && styles.pressed]}
+          >
+            <Text style={styles.warningLinkText}>Manage subscriptions in the App Store ›</Text>
+          </Pressable>
+        </View>
+
+        <View style={styles.confirmBlock}>
+          <Text style={styles.confirmLabel}>
+            Type {CONFIRMATION_WORD} to confirm you want all of this destroyed.
+          </Text>
+          <TextInput
+            value={typed}
+            onChangeText={setTyped}
+            placeholder={CONFIRMATION_WORD}
+            placeholderTextColor={theme.color.textFaint}
+            autoCapitalize="characters"
+            autoCorrect={false}
+            spellCheck={false}
+            editable={!deleting}
+            accessibilityLabel={`Type ${CONFIRMATION_WORD} to confirm`}
+            style={styles.input}
+          />
+        </View>
+
+        <Pressable
+          accessibilityRole="button"
+          accessibilityState={{ disabled: !confirmed || deleting }}
+          disabled={!confirmed || deleting}
+          onPress={handleDelete}
+          style={({ pressed }) => [
+            styles.deleteButton,
+            (!confirmed || deleting) && styles.deleteButtonDisabled,
+            pressed && styles.pressed,
+          ]}
+        >
+          {deleting ? (
+            <ActivityIndicator color={theme.color.text} />
+          ) : (
+            <Text style={styles.deleteButtonText}>Delete my account</Text>
+          )}
+        </Pressable>
+
+        <Pressable
+          accessibilityRole="button"
+          disabled={deleting}
+          onPress={() => router.back()}
+          style={({ pressed }) => [styles.cancel, pressed && styles.pressed]}
+        >
+          <Text style={styles.cancelText}>Keep my account</Text>
+        </Pressable>
+      </ScrollView>
+    </Screen>
+  );
+}
+
+/** `count` is optional: unknown reads as no number rather than as zero. */
+function Bullet({ text, count }: { text: string; count?: number | null }) {
+  return (
+    <View style={styles.bullet}>
+      <Text style={styles.bulletDot}>•</Text>
+      <Text style={styles.bulletText}>
+        {text}
+        {typeof count === 'number' ? <Text style={styles.bulletCount}> ({count})</Text> : null}
+      </Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  content: {
+    padding: theme.space(5),
+    gap: theme.space(5),
+    paddingBottom: theme.space(12),
+  },
+  lede: {
+    color: theme.color.text,
+    fontSize: theme.font.body,
+    lineHeight: 22,
+  },
+  card: {
+    backgroundColor: theme.color.surface,
+    borderRadius: theme.radius.md,
+    borderWidth: 1,
+    borderColor: theme.color.border,
+    padding: theme.space(4),
+    gap: theme.space(2),
+  },
+  cardTitle: {
+    color: theme.color.textFaint,
+    fontSize: theme.font.tiny,
+    fontWeight: '700',
+    letterSpacing: 1,
+    textTransform: 'uppercase',
+    marginBottom: theme.space(1),
+  },
+  bullet: {
+    flexDirection: 'row',
+    gap: theme.space(2),
+  },
+  bulletDot: {
+    color: theme.color.textFaint,
+    fontSize: theme.font.body,
+    lineHeight: 21,
+  },
+  bulletText: {
+    flex: 1,
+    color: theme.color.textMuted,
+    fontSize: theme.font.body,
+    lineHeight: 21,
+  },
+  bulletCount: {
+    color: theme.color.text,
+    fontWeight: '600',
+  },
+  warningCard: {
+    borderColor: theme.color.warning,
+    backgroundColor: theme.color.surfaceRaised,
+  },
+  warningTitle: {
+    color: theme.color.warning,
+    fontSize: theme.font.heading,
+    fontWeight: '700',
+  },
+  warningBody: {
+    color: theme.color.text,
+    fontSize: theme.font.body,
+    lineHeight: 21,
+  },
+  warningLink: {
+    paddingTop: theme.space(2),
+  },
+  warningLinkText: {
+    color: theme.color.accent,
+    fontSize: theme.font.body,
+    fontWeight: '600',
+  },
+  confirmBlock: {
+    gap: theme.space(2),
+  },
+  confirmLabel: {
+    color: theme.color.textMuted,
+    fontSize: theme.font.small,
+    lineHeight: 19,
+  },
+  input: {
+    backgroundColor: theme.color.surface,
+    borderRadius: theme.radius.sm,
+    borderWidth: 1,
+    borderColor: theme.color.border,
+    color: theme.color.text,
+    fontSize: theme.font.title,
+    fontWeight: '700',
+    letterSpacing: 3,
+    paddingHorizontal: theme.space(4),
+    paddingVertical: theme.space(3),
+    textAlign: 'center',
+  },
+  deleteButton: {
+    backgroundColor: theme.color.danger,
+    borderRadius: theme.radius.md,
+    alignItems: 'center',
+    justifyContent: 'center',
+    minHeight: 52,
+    paddingVertical: theme.space(4),
+  },
+  deleteButtonDisabled: {
+    opacity: 0.35,
+  },
+  deleteButtonText: {
+    color: theme.color.text,
+    fontSize: theme.font.heading,
+    fontWeight: '700',
+  },
+  cancel: {
+    alignItems: 'center',
+    paddingVertical: theme.space(3),
+  },
+  cancelText: {
+    color: theme.color.textMuted,
+    fontSize: theme.font.body,
+    fontWeight: '600',
+  },
+  pressed: {
+    opacity: 0.6,
+  },
+});

--- a/mobile/e2e/README.md
+++ b/mobile/e2e/README.md
@@ -1,6 +1,6 @@
 # End-to-end probes
 
-Four suites that exercise the backend the way the app does — through
+Five suites that exercise the backend the way the app does — through
 PostgREST as a real `anon`/`authenticated` user, so RLS is actually in play,
 and through the Cloud Functions over HTTP.
 
@@ -10,6 +10,7 @@ and through the Cloud Functions over HTTP.
 | `flow-probe.mjs` | Goal intake, prompt v1/v2 selection, free-tier metering, the 402 paywall, entitlement restore, coach-initiated nudges, `suppressUserTurn` auth, the nudge dispatcher sweep |
 | `viz-realtime-probe.mjs` | Visualiser guards (`no_aspiration`, entitlement, daily limit), prompt hygiene, likeness consent and reference photos, and realtime delivery of a coach-initiated message |
 | `sms-image-probe.mjs` | The daily SMS image job across three disciplines: channel scoping, coach resolution, goal-driven prompts, likeness consent, and that no member can receive fitness before/after imagery |
+| `account-deletion-probe.mjs` | Account deletion: that no row in any affected table survives, that the reference photo **object** is gone from the bucket, what happens to coaches the member created and to the people subscribed to them, and that a photo we cannot delete stops the whole deletion |
 
 ## Setting up a local stack
 
@@ -70,11 +71,21 @@ ENV_FILE=/tmp/cabo-local/local.env node e2e/rls-probe.mjs
 ENV_FILE=/tmp/cabo-local/local.env node e2e/flow-probe.mjs
 ENV_FILE=/tmp/cabo-local/local.env node e2e/viz-realtime-probe.mjs
 ENV_FILE=/tmp/cabo-local/local.env node e2e/sms-image-probe.mjs
+ENV_FILE=/tmp/cabo-local/local.env node e2e/account-deletion-probe.mjs
 ```
 
 `sms-image-probe.mjs` needs the mock model but not the gateway: it calls the
 daily job's modules in-process and fakes Replicate, Twilio and GCS, so it needs
 no Twilio or Replicate credentials and spends nothing.
+
+`account-deletion-probe.mjs` needs neither the gateway nor the mock model. It
+drives `functions/account-deletion` in process against `harness/fake-gcs.mjs`,
+a four-endpoint stand-in for the Cloud Storage JSON API that
+`@google-cloud/storage` talks to when `STORAGE_EMULATOR_HOST` is set — which is
+what lets it assert that the member's photo *object* is gone rather than that
+the column pointing at it is empty. It creates its own coaches, creators and
+members and removes all of them afterwards, including on failure, because the
+other suites assert on the exact contents of the seeded roster.
 
 They run from `mobile/` for `@supabase/supabase-js` resolution and exit non-zero
 on any failure.

--- a/mobile/e2e/account-deletion-probe.mjs
+++ b/mobile/e2e/account-deletion-probe.mjs
@@ -1,0 +1,479 @@
+/**
+ * Account deletion, end to end.
+ *
+ * App Store Review Guideline 5.1.1(v) is why the feature exists, but what this
+ * probe is actually for is the claim underneath it: that a member who asks to
+ * be deleted is deleted. `member_goals` holds what someone is struggling with,
+ * `conversation_messages` holds every word they have said to a coach, and the
+ * member-media bucket holds a photograph of their face.
+ *
+ *   node e2e/account-deletion-probe.mjs      (from mobile/, with ENV_FILE set)
+ *
+ * Needs the local Supabase stack and the example roster seed. It does NOT need
+ * GCS credentials or the function gateway: it drives `functions/account-deletion`
+ * in process against a fake Cloud Storage JSON API, so the real
+ * `@google-cloud/storage` client issues real list and delete calls and the
+ * object is observably gone at the end rather than merely unreferenced.
+ *
+ * Four things it sets out to prove:
+ *
+ *   1. No row in any affected table still references the member, and the auth
+ *      identity is gone, and signing back in gets a genuinely new account.
+ *   2. The stored photo object is gone from the bucket.
+ *   3. A coach the member created that other people subscribe to survives, and
+ *      those people's threads, entitlements and roster reads survive with it —
+ *      because `coach_profiles` used to cascade off both owner columns, which
+ *      would have deleted it and everything hanging off it.
+ *   4. If the photo cannot be deleted, nothing is deleted.
+ *
+ * Everything it creates is torn down at the end, including on failure: the
+ * other suites assert on the exact contents of the seeded roster.
+ */
+import { createClient } from '@supabase/supabase-js';
+import { createRequire } from 'node:module';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { startFakeGcs } from './harness/fake-gcs.mjs';
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(here, '../..');
+const require = createRequire(import.meta.url);
+
+const env = Object.fromEntries(
+  fs.readFileSync(process.env.ENV_FILE, 'utf8').split('\n').filter(Boolean).map((l) => {
+    const i = l.indexOf('=');
+    return [l.slice(0, i), l.slice(i + 1).replace(/^"|"$/g, '')];
+  })
+);
+
+const URL_ = env.API_URL;
+const ANON = env.ANON_KEY;
+const SERVICE = env.SERVICE_ROLE_KEY;
+
+const admin = createClient(URL_, SERVICE, { auth: { persistSession: false } });
+
+let pass = 0, fail = 0;
+const check = (n, ok, d = '') =>
+  ok ? (pass++, console.log(`  ok    ${n}`)) : (fail++, console.log(`  FAIL  ${n}${d ? ` — ${d}` : ''}`));
+const section = (t) => console.log(`\n### ${t}`);
+
+const BUCKET = 'local-test-member-media';
+const POCKET = 'a1000000-0000-4000-8000-000000000001';
+const DEV_CREATOR_SLUG = 'dev-okafor';
+
+// ---------------------------------------------------------------------------
+// Fake Cloud Storage, then the function — in that order, because the function
+// builds its Storage client at require time.
+// ---------------------------------------------------------------------------
+const gcs = await startFakeGcs();
+process.env.STORAGE_EMULATOR_HOST = gcs.emulatorHost;
+process.env.SUPABASE_URL = URL_;
+process.env.SUPABASE_SERVICE_ROLE_KEY = SERVICE;
+process.env.MEMBER_MEDIA_BUCKET = BUCKET;
+process.env.PROJECT_ID = 'local-test';
+
+const { deleteAccount } = require(path.join(repoRoot, 'functions/account-deletion/index.js'));
+
+/** The Cloud Functions request/response pair, minus Express. */
+async function callFunction({ path: p = '/', token, body = {} }) {
+  const req = {
+    method: 'POST',
+    path: p,
+    body,
+    get: (h) => (h.toLowerCase() === 'authorization' ? (token ? `Bearer ${token}` : undefined) : undefined),
+  };
+
+  let status = 200;
+  let payload;
+  const res = {
+    set: () => res,
+    status: (c) => { status = c; return res; },
+    json: (b) => { payload = b; return res; },
+    send: (b) => { payload = b; return res; },
+  };
+
+  await deleteAccount(req, res);
+  return { status, body: payload };
+}
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+const stamp = Date.now();
+const created = { users: [], coaches: [], creators: [], profiles: [] };
+
+async function makeMember(label) {
+  const email = `del-${label}-${stamp}@example.com`;
+  const password = 'probe-password-123';
+  const { data, error } = await admin.auth.admin.createUser({
+    email, password, email_confirm: true,
+  });
+  if (error) throw new Error(`create ${label}: ${error.message}`);
+  created.users.push(data.user.id);
+
+  const client = createClient(URL_, ANON, { auth: { persistSession: false } });
+  const { data: session, error: signInError } = await client.auth.signInWithPassword({ email, password });
+  if (signInError) throw new Error(`sign in ${label}: ${signInError.message}`);
+
+  await admin.from('user_profiles').upsert(
+    {
+      user_id: data.user.id,
+      email,
+      full_name: `Probe ${label}`,
+      display_name: `Probe ${label}`,
+      auth_provider: 'email',
+      coach: null,
+      coach_type: null,
+      onboarded_at: new Date().toISOString(),
+    },
+    { onConflict: 'email' }
+  );
+  created.profiles.push(email);
+
+  return { id: data.user.id, email, password, client, token: session.session.access_token };
+}
+
+/** A coach owned by `owner`, optionally attributed to somebody else's creator. */
+async function makeCoach({ name, owner, creatorId, listing = 'listed' }) {
+  const { data, error } = await admin
+    .from('coach_profiles')
+    .insert({
+      user_id: creatorId ? null : owner.id,
+      user_email: owner.email,
+      creator_id: creatorId ?? null,
+      name,
+      handle: `${name.toLowerCase()}${stamp}`.slice(0, 30),
+      description: 'Probe fixture.',
+      discipline: 'Probe fixture',
+      category_slug: 'other',
+      primary_response_style: 'tough_love',
+      active: true,
+      public: false,
+      listing_status: listing,
+    })
+    .select('id')
+    .single();
+  if (error) throw new Error(`create coach ${name}: ${error.message}`);
+  created.coaches.push(data.id);
+  return data.id;
+}
+
+async function cleanup() {
+  for (const id of created.coaches) await admin.from('coach_profiles').delete().eq('id', id);
+  for (const id of created.creators) await admin.from('creator_profiles').delete().eq('id', id);
+  for (const email of created.profiles) await admin.from('user_profiles').delete().eq('email', email);
+  for (const id of created.users) await admin.auth.admin.deleteUser(id).catch(() => {});
+  await gcs.close();
+}
+
+let exitCode = 0;
+try {
+
+// ---------------------------------------------------------------------------
+section('Set up a member with a full footprint');
+// ---------------------------------------------------------------------------
+const alice = await makeMember('alice');   // the one who leaves
+const bob   = await makeMember('bob');     // a paying subscriber to her coach
+
+// Alice is a creator with two coaches of her own, plus one that is really
+// somebody else's and only carries her address in the legacy owner column —
+// the shape the five default personas are in.
+const { data: aliceCreator, error: creatorError } = await admin
+  .from('creator_profiles')
+  .insert({
+    user_id: alice.id,
+    user_email: alice.email,
+    display_name: 'Alice Probe',
+    slug: `alice-probe-${stamp}`.slice(0, 40),
+    bio: 'Personal, and should not survive her.',
+    status: 'approved',
+  })
+  .select('id')
+  .single();
+check('creator profile for the departing member', !creatorError, creatorError?.message);
+if (aliceCreator) created.creators.push(aliceCreator.id);
+
+const { data: devCreator } = await admin
+  .from('creator_profiles').select('id').eq('slug', DEV_CREATOR_SLUG).single();
+
+const lonelyCoach   = await makeCoach({ name: 'Lonely', owner: alice, creatorId: aliceCreator.id, listing: 'draft' });
+const popularCoach  = await makeCoach({ name: 'Popular', owner: alice, creatorId: aliceCreator.id });
+const borrowedCoach = await makeCoach({ name: 'Borrowed', owner: alice, creatorId: devCreator.id });
+
+// Alice's own data: a thread with messages, a goal, an image, a device, a
+// subscription, and a photograph of her face.
+const { data: convId, error: convError } = await alice.client.rpc('open_coach_conversation', { p_coach_id: POCKET });
+check('thread opened', !convError && !!convId, convError?.message);
+
+await admin.from('conversation_messages').insert([
+  { conversation_id: convId, role: 'user', content: 'The thing I am most ashamed of.' },
+  { conversation_id: convId, role: 'assistant', content: 'Heard.' },
+]);
+await admin.from('member_goals').insert({
+  user_id: alice.id, coach_id: POCKET, aspiration: 'someone who finishes things', onboarding_status: 'complete',
+});
+await admin.from('coach_visualizations').insert({
+  user_id: alice.id, coach_id: POCKET, kind: 'becoming', scene: 'a stage', status: 'ready',
+  image_url: 'https://example.invalid/x.jpg',
+});
+await admin.from('push_devices').insert({
+  user_id: alice.id, expo_token: `ExponentPushToken[probe-${stamp}]`, platform: 'ios',
+});
+await admin.from('coach_nudges').insert({
+  user_id: alice.id, coach_id: POCKET, local_date: '2026-08-11', status: 'sent', body: 'hello',
+});
+
+const PHOTO = `member-reference/${alice.id}/reference.jpg`;
+// Two objects, one under an older extension, because revocation sweeps the
+// prefix rather than the one path the column happens to name — and so must this.
+const STALE_PHOTO = `member-reference/${alice.id}/reference.png`;
+gcs.put(BUCKET, PHOTO, Buffer.from('a photograph of her face'));
+gcs.put(BUCKET, STALE_PHOTO, Buffer.from('an older one'));
+
+const { error: photoError } = await admin
+  .from('user_profiles')
+  .update({
+    likeness_consent: true,
+    likeness_consent_at: new Date().toISOString(),
+    reference_photo_url: `gs://${BUCKET}/${PHOTO}`,
+    reference_photo_updated_at: new Date().toISOString(),
+  })
+  .eq('user_id', alice.id);
+check('reference photo recorded', !photoError, photoError?.message);
+check('photo objects are in the bucket to start with', gcs.list(BUCKET, `member-reference/${alice.id}/`).length === 2);
+
+// Bob subscribes to Alice's popular coach and talks to it, so deleting it
+// would take his history with it.
+await admin.from('coach_subscriptions').insert({
+  user_id: bob.id, user_email: bob.email, coach_id: popularCoach, status: 'active', source: 'ios_iap',
+});
+const { data: bobConv } = await bob.client.rpc('open_coach_conversation', { p_coach_id: popularCoach });
+check('other member has a thread with her coach', !!bobConv);
+
+const { data: beforeCounts } = await admin
+  .from('coach_profiles').select('id, subscriber_count').in('id', [POCKET, popularCoach]);
+const pocketBefore = beforeCounts.find((c) => c.id === POCKET)?.subscriber_count ?? 0;
+
+// ---------------------------------------------------------------------------
+section('The confirmation screen is told the truth');
+// ---------------------------------------------------------------------------
+{
+  const { status, body } = await callFunction({ path: '/preview', token: alice.token });
+  check('preview requires nothing but a session', status === 200, JSON.stringify(body));
+  check('  → counts her conversations', body?.summary?.conversations === 1, JSON.stringify(body?.summary));
+  check('  → counts her goals', body?.summary?.goals === 1);
+  check('  → counts her images', body?.summary?.images === 1);
+  check('  → says there is a photo of her', body?.summary?.hasReferencePhoto === true);
+}
+
+// ---------------------------------------------------------------------------
+section('Nothing deletes by accident');
+// ---------------------------------------------------------------------------
+{
+  const anonymous = await callFunction({ path: '/', body: { confirm: 'DELETE' } });
+  check('no session, no deletion', anonymous.status === 401, JSON.stringify(anonymous.body));
+
+  const unconfirmed = await callFunction({ path: '/', token: alice.token, body: {} });
+  check('empty body is refused', unconfirmed.status === 400, JSON.stringify(unconfirmed.body));
+
+  const wrongWord = await callFunction({ path: '/', token: alice.token, body: { confirm: 'delete-it' } });
+  check('a near-miss confirmation is refused', wrongWord.status === 400, JSON.stringify(wrongWord.body));
+
+  const truthy = await callFunction({ path: '/', token: alice.token, body: { confirm: true } });
+  check('a truthy value is not a confirmation', truthy.status === 400, JSON.stringify(truthy.body));
+
+  const { count } = await admin
+    .from('user_profiles').select('id', { count: 'exact', head: true }).eq('user_id', alice.id);
+  check('  → her profile is still there after all four', count === 1);
+}
+
+// ---------------------------------------------------------------------------
+section('A photo we cannot delete stops the whole deletion');
+// ---------------------------------------------------------------------------
+{
+  gcs.failMode = 'delete';
+  const { status, body } = await callFunction({ path: '/', token: alice.token, body: { confirm: 'DELETE' } });
+
+  check('refuses with a retryable status', status === 503, `${status} ${JSON.stringify(body)}`);
+  check('  → and says so in words a member can act on', /photo/i.test(body?.message ?? ''), body?.message);
+
+  const { count: profiles } = await admin
+    .from('user_profiles').select('id', { count: 'exact', head: true }).eq('user_id', alice.id);
+  const { count: messages } = await admin
+    .from('conversation_messages').select('id', { count: 'exact', head: true }).eq('conversation_id', convId);
+  check('  → her profile survived', profiles === 1);
+  check('  → her messages survived', messages === 2);
+  check('  → a photo of her survived, so the account was not erased around it',
+        gcs.list(BUCKET, `member-reference/${alice.id}/`).length > 0);
+
+  /*
+    The deletes go out in parallel and the sweep gives up on the first
+    rejection, so one of the others can still be in flight when the flag is
+    cleared. Let them land, then put the prefix back the way it was — asserting
+    on the outcome of that race would be asserting on nothing.
+  */
+  await new Promise((resolve) => setTimeout(resolve, 500));
+  gcs.failMode = null;
+  gcs.put(BUCKET, PHOTO, Buffer.from('a photograph of her face'));
+  gcs.put(BUCKET, STALE_PHOTO, Buffer.from('an older one'));
+}
+
+// ---------------------------------------------------------------------------
+section('She deletes her account');
+// ---------------------------------------------------------------------------
+const deletion = await callFunction({ path: '/', token: alice.token, body: { confirm: 'DELETE' } });
+check('deletion succeeds', deletion.status === 200, JSON.stringify(deletion.body));
+check('  → reports both photo objects deleted', deletion.body?.photosDeleted === 2, String(deletion.body?.photosDeleted));
+
+// ---------------------------------------------------------------------------
+section('The photograph is actually gone from the bucket');
+// ---------------------------------------------------------------------------
+{
+  check('the named object is gone', !gcs.has(BUCKET, PHOTO));
+  check('the object under the older extension is gone too', !gcs.has(BUCKET, STALE_PHOTO));
+  check('nothing is left under her prefix', gcs.list(BUCKET, `member-reference/${alice.id}/`).length === 0);
+
+  // Ordering is the point of the whole design: the object goes before the row
+  // that points at it, because once the row is gone nothing knows the object
+  // is there.
+  const deletes = gcs.calls('delete').filter((c) => c.object.includes(alice.id));
+  check('the client really issued the deletes', deletes.length >= 2, JSON.stringify(deletes.map((d) => d.object)));
+  check('swept by prefix, not by the column', gcs.calls('list').some((c) => c.prefix === `member-reference/${alice.id}/`));
+}
+
+// ---------------------------------------------------------------------------
+section('No row anywhere still references her');
+// ---------------------------------------------------------------------------
+{
+  const byUserId = [
+    'member_goals', 'conversations', 'coach_subscriptions',
+    'push_devices', 'coach_visualizations', 'coach_nudges',
+  ];
+  for (const table of byUserId) {
+    const { count, error } = await admin
+      .from(table).select('id', { count: 'exact', head: true }).eq('user_id', alice.id);
+    check(`${table} has nothing for her`, !error && count === 0, error?.message ?? `count=${count}`);
+  }
+
+  const { count: profiles } = await admin
+    .from('user_profiles').select('id', { count: 'exact', head: true }).eq('user_id', alice.id);
+  check('user_profiles has nothing for her', profiles === 0);
+
+  const { count: byEmail } = await admin
+    .from('user_profiles').select('id', { count: 'exact', head: true }).eq('email', alice.email);
+  check('  → nor under her email', byEmail === 0);
+
+  const { count: messages } = await admin
+    .from('conversation_messages').select('id', { count: 'exact', head: true }).eq('conversation_id', convId);
+  check('conversation_messages has nothing for her', messages === 0);
+
+  const { data: authUser } = await admin.auth.admin.getUserById(alice.id);
+  check('the auth identity is gone', !authUser?.user, authUser?.user?.id);
+}
+
+// ---------------------------------------------------------------------------
+section('Her coaches: kept, unlisted or deleted, never orphaned');
+// ---------------------------------------------------------------------------
+{
+  const { data: lonely } = await admin.from('coach_profiles').select('id').eq('id', lonelyCoach).maybeSingle();
+  check('the coach nobody else used is deleted', !lonely);
+
+  const { data: popular } = await admin
+    .from('coach_profiles')
+    .select('id, active, listing_status, user_id, user_email, creator_id')
+    .eq('id', popularCoach).maybeSingle();
+  check('the coach with a paying subscriber survives', !!popular);
+  check('  → still active, so his thread still works', popular?.active === true);
+  check('  → unlisted, so nobody new subscribes to an unowned coach', popular?.listing_status === 'unlisted');
+  check('  → no longer linked to her', popular?.user_id === null && popular?.user_email === null,
+        JSON.stringify({ user_id: popular?.user_id, user_email: popular?.user_email }));
+
+  const { data: borrowed } = await admin
+    .from('coach_profiles')
+    .select('id, listing_status, user_id, user_email, creator_id')
+    .eq('id', borrowedCoach).maybeSingle();
+  check('a coach belonging to another creator is not touched', !!borrowed);
+  check('  → still listed (this is the default-personas case)', borrowed?.listing_status === 'listed');
+  check('  → but her personal link is cut', borrowed?.user_id === null && borrowed?.user_email === null);
+  check('  → attribution intact', borrowed?.creator_id === devCreator.id);
+
+  const { data: creator } = await admin
+    .from('creator_profiles')
+    .select('id, user_id, user_email, display_name, slug, bio, status')
+    .eq('id', aliceCreator.id).maybeSingle();
+  check('her creator profile survives only because a coach needs it', !!creator);
+  check('  → detached from the account', creator?.user_id === null);
+  check('  → name, bio and email scrubbed', creator?.display_name === 'Former creator' &&
+        creator?.bio === null && creator?.user_email !== alice.email,
+        JSON.stringify(creator));
+  check('  → and the slug, which is usually a real name', !creator?.slug?.includes('alice-probe'), creator?.slug);
+}
+
+// ---------------------------------------------------------------------------
+section('Nothing she left behind breaks anyone else');
+// ---------------------------------------------------------------------------
+{
+  const { data: mine, error } = await bob.client.rpc('get_my_coaches');
+  check('get_my_coaches still works for the subscriber', !error, error?.message);
+  const kept = mine?.find((c) => c.coach_id === popularCoach);
+  check('  → her coach is still in his list', !!kept, JSON.stringify(mine?.map((c) => c.name)));
+  check('  → with his thread', !!kept?.conversation_id);
+  check('  → and his entitlement', kept?.has_access === true, JSON.stringify({ status: kept?.status }));
+  check('  → attributed to the scrubbed creator, not to nobody', kept?.creator_name === 'Former creator', kept?.creator_name);
+
+  const anonClient = createClient(URL_, ANON, { auth: { persistSession: false } });
+  const { data: roster, error: rosterError } = await anonClient.rpc('get_coach_roster', {
+    p_category: null, p_search: null, p_limit: 100, p_offset: 0,
+  });
+  check('get_coach_roster still works', !rosterError, rosterError?.message);
+  check('  → the unlisted coach is off the roster', !roster?.some((c) => c.id === popularCoach));
+  check('  → the other creator\'s coach is still on it', roster?.some((c) => c.id === borrowedCoach));
+
+  const { data: counts } = await admin
+    .from('coach_profiles').select('id, subscriber_count').in('id', [POCKET, popularCoach]);
+  check('subscriber_count fell by one where she unsubscribed',
+        counts.find((c) => c.id === POCKET)?.subscriber_count === pocketBefore - 1,
+        JSON.stringify(counts));
+  check('  → and is unchanged where the subscriber stayed',
+        counts.find((c) => c.id === popularCoach)?.subscriber_count === 1,
+        JSON.stringify(counts));
+}
+
+// ---------------------------------------------------------------------------
+section('Signing in again is a new account, not a resurrection');
+// ---------------------------------------------------------------------------
+{
+  const { data: again, error } = await admin.auth.admin.createUser({
+    email: alice.email, password: alice.password, email_confirm: true,
+  });
+  check('the email can be used again', !error && !!again?.user, error?.message);
+
+  if (again?.user) {
+    created.users.push(again.user.id);
+    check('  → and it is a different identity', again.user.id !== alice.id);
+
+    const { count } = await admin
+      .from('conversations').select('id', { count: 'exact', head: true }).eq('user_id', again.user.id);
+    check('  → with no history', count === 0);
+  }
+}
+
+// ---------------------------------------------------------------------------
+section('The old access token is dead');
+// ---------------------------------------------------------------------------
+{
+  const { status } = await callFunction({ path: '/preview', token: alice.token });
+  check('a token for a deleted account authenticates nothing', status === 401);
+}
+
+} catch (error) {
+  fail++;
+  console.error('\nprobe threw:', error);
+} finally {
+  await cleanup();
+}
+
+console.log(`\n${pass} passed, ${fail} failed`);
+exitCode = fail === 0 ? 0 : 1;
+process.exit(exitCode);

--- a/mobile/e2e/harness/fake-gcs.mjs
+++ b/mobile/e2e/harness/fake-gcs.mjs
@@ -1,0 +1,114 @@
+/**
+ * A four-endpoint stand-in for the Cloud Storage JSON API.
+ *
+ * `@google-cloud/storage` sends every request to `STORAGE_EMULATOR_HOST` when
+ * that variable is set, and skips credentials entirely, so a probe can watch
+ * the real client issue real list and delete calls without a service account.
+ *
+ * This exists for one assertion that cannot be made any other way: that
+ * deleting an account deletes the *object* holding the member's photograph, not
+ * just the row pointing at it. Asserting on the column is asserting on the part
+ * that was never in doubt.
+ *
+ *   const gcs = await startFakeGcs();
+ *   process.env.STORAGE_EMULATOR_HOST = gcs.emulatorHost;   // before require()
+ *   gcs.put('bucket', 'member-reference/<id>/reference.jpg', bytes);
+ *   gcs.list('bucket', 'member-reference/<id>/')            // -> [names]
+ *
+ * `gcs.failMode = 'delete'` makes every delete fail, which is how the "we will
+ * not erase the account while a photo of them survives" path gets exercised.
+ * It answers 401 rather than 503 on purpose: the client retries 5xx with
+ * exponential backoff, so a probe asserting on the give-up path would spend
+ * half a minute waiting to observe something a permission error shows instantly.
+ */
+import http from 'node:http';
+
+export async function startFakeGcs({ port = 0 } = {}) {
+  /** bucket -> Map(objectName -> Buffer) */
+  const buckets = new Map();
+  const requests = [];
+
+  const bucketOf = (name) => {
+    if (!buckets.has(name)) buckets.set(name, new Map());
+    return buckets.get(name);
+  };
+
+  const state = {
+    failMode: null, // null | 'delete' | 'list'
+    requests,
+    put(bucket, name, bytes = Buffer.from('jpeg')) {
+      bucketOf(bucket).set(name, Buffer.from(bytes));
+    },
+    list(bucket, prefix = '') {
+      return [...bucketOf(bucket).keys()].filter((n) => n.startsWith(prefix)).sort();
+    },
+    has(bucket, name) {
+      return bucketOf(bucket).has(name);
+    },
+    /** Every list/delete the client actually made, for ordering assertions. */
+    calls(kind) {
+      return requests.filter((r) => r.kind === kind);
+    },
+  };
+
+  const server = http.createServer((req, res) => {
+    const url = new URL(req.url, 'http://localhost');
+    const json = (code, body) => {
+      res.writeHead(code, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify(body));
+    };
+
+    // /storage/v1/b/<bucket>/o          list
+    // /storage/v1/b/<bucket>/o/<name>   get metadata / delete
+    const match = url.pathname.match(/^\/storage\/v1\/b\/([^/]+)\/o(?:\/(.+))?$/);
+    if (!match) return json(404, { error: { message: `unhandled ${req.method} ${url.pathname}` } });
+
+    const bucket = decodeURIComponent(match[1]);
+    const object = match[2] ? decodeURIComponent(match[2]) : null;
+
+    if (req.method === 'GET' && object === null) {
+      requests.push({ kind: 'list', bucket, prefix: url.searchParams.get('prefix') });
+      if (state.failMode === 'list') return json(401, { error: { message: 'fake credentials failure' } });
+
+      const prefix = url.searchParams.get('prefix') || '';
+      return json(200, {
+        kind: 'storage#objects',
+        items: state.list(bucket, prefix).map((name) => ({
+          kind: 'storage#object',
+          id: `${bucket}/${name}`,
+          name,
+          bucket,
+          size: String(bucketOf(bucket).get(name).length),
+        })),
+      });
+    }
+
+    if (req.method === 'GET') {
+      requests.push({ kind: 'get', bucket, object });
+      if (!state.has(bucket, object)) return json(404, { error: { message: 'Not Found' } });
+      return json(200, { kind: 'storage#object', name: object, bucket });
+    }
+
+    if (req.method === 'DELETE' && object !== null) {
+      requests.push({ kind: 'delete', bucket, object });
+      if (state.failMode === 'delete') return json(401, { error: { message: 'fake credentials failure' } });
+      if (!bucketOf(bucket).delete(object)) return json(404, { error: { message: 'Not Found' } });
+      res.writeHead(204).end();
+      return;
+    }
+
+    return json(405, { error: { message: `unhandled ${req.method}` } });
+  });
+
+  await new Promise((resolve) => server.listen(port, '127.0.0.1', resolve));
+  const actual = server.address().port;
+
+  // Assign onto `state` rather than spreading it: the server closure reads
+  // `state.failMode`, and a copy would leave the caller flipping a flag nothing
+  // ever looks at.
+  return Object.assign(state, {
+    port: actual,
+    emulatorHost: `http://127.0.0.1:${actual}/storage/v1`,
+    close: () => new Promise((resolve) => server.close(resolve)),
+  });
+}

--- a/mobile/e2e/harness/function-gateway.js
+++ b/mobile/e2e/harness/function-gateway.js
@@ -77,6 +77,13 @@ process.env.COACH_RESPONSE_GENERATOR_URL = `http://127.0.0.1:${PORT}/coach-respo
 mount('/coach-response-generator', 'coach-response-generator', 'generateCoachResponse');
 mount('/coach-nudges', 'coach-nudges', 'coachNudges');
 mount('/coach-visualizer', 'coach-visualizer', 'coachVisualizer');
+/*
+  Mounted so the app's Settings flow can be driven end to end against a local
+  stack. It reaches a real bucket, so deleting an account through the gateway
+  needs GCS credentials — `account-deletion-probe.mjs` drives the same handler
+  in process against a fake Cloud Storage API instead, and needs none.
+*/
+mount('/account-deletion', 'account-deletion', 'deleteAccount');
 
 app.get('/health', (_req, res) => res.json({ ok: true }));
 

--- a/mobile/src/lib/api.ts
+++ b/mobile/src/lib/api.ts
@@ -50,6 +50,16 @@ async function callFunction<T>(path: string, body: unknown): Promise<T> {
     }
 
     /*
+      503 is the one server error worth rendering: it is the deliberate "this
+      cannot be done right now, try again shortly" that account deletion
+      returns when the stored photo could not be deleted, and telling someone
+      to try again is more use than telling them nothing.
+    */
+    if (response.status === 503 && typeof payload.message === 'string') {
+      throw new Error(payload.message);
+    }
+
+    /*
       4xx bodies carry a message written for the member. 5xx bodies must not be
       rendered even if the server sends detail — a stack or a cloud-provider
       JSON blob in an alert is worse than saying nothing useful.
@@ -424,4 +434,43 @@ export async function updateCoachNotifications(
 /** Fires a real notification to this account's devices, to prove the wiring. */
 export async function sendTestNotification(coachId: string) {
   return callFunction<{ success: boolean; ok: number }>('/coach-nudges/preview', { coachId });
+}
+
+// ---------------------------------------------------------------------------
+// Account deletion
+// ---------------------------------------------------------------------------
+
+export interface DeletionSummary {
+  conversations: number | null;
+  goals: number | null;
+  images: number | null;
+  subscriptions: number | null;
+  hasReferencePhoto: boolean;
+}
+
+/**
+ * What deleting would destroy, counted live.
+ *
+ * The confirmation is worth more when it says "4 conversations and 2 goals"
+ * than when it lists table names, and someone who has nothing stored should be
+ * told that rather than warned about it.
+ */
+export async function fetchDeletionSummary(): Promise<DeletionSummary> {
+  const { summary } = await callFunction<{ summary: DeletionSummary }>(
+    '/account-deletion/preview',
+    {}
+  );
+  return summary;
+}
+
+/**
+ * Irreversible. The caller is responsible for having got a deliberate
+ * confirmation first — see `app/delete-account.tsx`, which makes the member
+ * type the word.
+ *
+ * The literal string is what the server checks, so a retry with an empty body
+ * cannot delete anything.
+ */
+export async function deleteAccount(): Promise<void> {
+  await callFunction<{ success: boolean }>('/account-deletion', { confirm: 'DELETE' });
 }

--- a/supabase/migrations/20260812090000_account_deletion.sql
+++ b/supabase/migrations/20260812090000_account_deletion.sql
@@ -1,0 +1,335 @@
+/*
+  # Account deletion
+
+  App Store Review Guideline 5.1.1(v): an app that creates accounts must let
+  people delete them from inside the app. Cabo creates them two ways (Sign in
+  with Apple, email OTP) and had no delete path at all.
+
+  This is not only a compliance chore. `member_goals` holds what someone is
+  struggling with, `conversation_messages` holds their coaching history, and
+  `user_profiles.reference_photo_url` points at a photograph of their face. A
+  member who asks to be deleted has to actually be deleted.
+
+  Three things live here:
+
+    1. Two foreign keys that would have made deletion catastrophic.
+    2. `delete_member_account(uuid)` — the whole public-schema cascade, in one
+       transaction, callable only by the service role.
+    3. A policy for coaches the departing member created, because "cascade" and
+       "orphan" are both wrong answers there.
+
+  The storage object behind `reference_photo_url` is *not* deleted here — SQL
+  cannot reach a GCS bucket. `functions/account-deletion` deletes the object
+  first and calls this function second, which is the same ordering the likeness
+  revocation path in `coach-visualizer` uses and for the same reason: an erasure
+  that only cleared a pointer is not an erasure.
+*/
+
+-- ---------------------------------------------------------------------------
+-- 1. Two foreign keys that turned "delete one member" into "delete the roster"
+-- ---------------------------------------------------------------------------
+
+/*
+  `coach_profiles` was written when a coach belonged to the account that built
+  it, before creators existed and before anybody could subscribe to somebody
+  else's coach. Both of its owner links cascade:
+
+      user_id    uuid REFERENCES auth.users(id)          ON DELETE CASCADE
+      user_email text REFERENCES user_profiles(email)     ON DELETE CASCADE
+
+  So deleting one auth.users row silently deletes every coach that person owns,
+  and each of those cascades into `coach_subscriptions`, `conversations`,
+  `conversation_messages`, `member_goals`, `coach_content_chunks`,
+  `coach_iap_products` and `coach_nudges` — for *other people*, who are paying
+  Apple for that coach every month.
+
+  Worse in practice: `20250531093301_add_predefined_coaches.sql` seeded the five
+  default personas against the founder's own `user_profiles` row, and
+  `20260811090100` deliberately left `user_email` alone when it repointed their
+  attribution at the platform creator. The founder deleting their own account
+  would have taken Zen Master, Gym Bro, Dance Teacher, Drill Sergeant and Frat
+  Bro with it.
+
+  Ownership is a link, not a life dependency. Both become SET NULL, which means
+  the worst case is now an unowned coach rather than a deleted one — and
+  `delete_member_account` below never leans on either, it decides explicitly.
+*/
+
+ALTER TABLE public.coach_profiles DROP CONSTRAINT IF EXISTS coach_profiles_user_id_fkey;
+ALTER TABLE public.coach_profiles
+    ADD CONSTRAINT coach_profiles_user_id_fkey
+    FOREIGN KEY (user_id) REFERENCES auth.users(id) ON DELETE SET NULL;
+
+-- NOT NULL has to go with it: SET NULL cannot fire on a NOT NULL column, and a
+-- detached coach genuinely has no owner email to record.
+ALTER TABLE public.coach_profiles ALTER COLUMN user_email DROP NOT NULL;
+
+ALTER TABLE public.coach_profiles DROP CONSTRAINT IF EXISTS coach_profiles_user_email_fkey;
+ALTER TABLE public.coach_profiles
+    ADD CONSTRAINT coach_profiles_user_email_fkey
+    FOREIGN KEY (user_email) REFERENCES public.user_profiles(email) ON DELETE SET NULL;
+
+COMMENT ON COLUMN public.coach_profiles.user_email
+    IS 'Legacy owner link, read by the pre-creator RLS policies. NULL once the owning account is deleted; attribution comes from creator_id.';
+
+/*
+  The RLS policies that read `user_email` compare it with
+  `lower(auth.jwt() ->> ''email'')`. NULL never equals anything, so a detached
+  coach simply has no owner by that route — which is the intent. The `user_id`
+  branch behaves the same way. No policy needs changing.
+*/
+
+-- ---------------------------------------------------------------------------
+-- 2. The cascade
+-- ---------------------------------------------------------------------------
+
+/*
+  One function rather than a list of DELETEs in JavaScript, for three reasons:
+  it is a single transaction (a half-deleted account is worse than a live one),
+  it can read `auth.users` to catch legacy profile rows that were never linked
+  by `user_id`, and the ordering constraints below live next to the schema they
+  depend on instead of in a comment in another language.
+
+  Returns a JSON summary so the caller can log what actually went, and so the
+  probe can assert on it.
+
+  Not deleted here, on purpose:
+    * the `auth.users` row — the caller does that through GoTrue's admin API so
+      identities, sessions and refresh tokens go with it;
+    * the reference photo object — the caller deletes that first.
+*/
+CREATE OR REPLACE FUNCTION public.delete_member_account(p_user_id uuid)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_email        text;
+  v_emails       text[];
+  v_phones       text[];
+  v_creator_ids  uuid[];
+  v_coach        record;
+  v_deleted      jsonb := '{}'::jsonb;
+  v_n            integer;
+  v_coaches_deleted  uuid[] := '{}';
+  v_coaches_retained uuid[] := '{}';
+  v_coaches_detached uuid[] := '{}';
+  v_creators_deleted uuid[] := '{}';
+  v_creators_kept    uuid[] := '{}';
+BEGIN
+  IF p_user_id IS NULL THEN
+    RAISE EXCEPTION 'delete_member_account requires a user id';
+  END IF;
+
+  -- The auth row is the identity; the email is how the legacy, phone-era rows
+  -- are linked. Read it before anything else deletes it.
+  SELECT lower(email) INTO v_email FROM auth.users WHERE id = p_user_id;
+
+  /*
+    A member may hold more than one `user_profiles` row historically: one keyed
+    by `user_id` (app sign-in) and one keyed by `email` or by `id` = the auth id
+    (the SMS funnel, and `handle_new_user`'s ON CONFLICT (id) insert). Collect
+    every address and phone they own so nothing is missed.
+  */
+  SELECT array_agg(DISTINCT lower(email)) FILTER (WHERE email IS NOT NULL),
+         array_agg(DISTINCT phone_number) FILTER (WHERE phone_number IS NOT NULL)
+    INTO v_emails, v_phones
+    FROM public.user_profiles
+   WHERE user_id = p_user_id
+      OR id = p_user_id
+      OR (v_email IS NOT NULL AND lower(email) = v_email);
+
+  v_emails := COALESCE(v_emails, '{}');
+  IF v_email IS NOT NULL AND NOT (v_email = ANY(v_emails)) THEN
+    v_emails := v_emails || v_email;
+  END IF;
+  v_phones := COALESCE(v_phones, '{}');
+
+  SELECT COALESCE(array_agg(id), '{}') INTO v_creator_ids
+    FROM public.creator_profiles
+   WHERE user_id = p_user_id
+      OR (array_length(v_emails, 1) IS NOT NULL AND lower(user_email) = ANY(v_emails));
+
+  -- -------------------------------------------------------------------------
+  -- 2a. Coaches this member owns
+  -- -------------------------------------------------------------------------
+  /*
+    Three outcomes, and the difference matters:
+
+      detached  The coach is attributed to somebody else's creator — most
+                importantly the platform creator, which owns the five default
+                personas but still carries the founder's address in the legacy
+                `user_email` column. Only the personal link is cut.
+
+      retained  Their own coach, but other members are subscribed to it. Those
+                people are paying Apple monthly; deleting it would take their
+                threads and their goals with it. The coach stays and keeps
+                working for its existing subscribers, unowned and unlisted so
+                nobody new can subscribe to a coach with nobody behind it.
+
+      deleted   Their own coach that nobody else uses. Their creation, their
+                data, and no one is harmed by it going.
+  */
+  FOR v_coach IN
+    SELECT cp.id, cp.creator_id
+      FROM public.coach_profiles cp
+     WHERE cp.user_id = p_user_id
+        OR (array_length(v_emails, 1) IS NOT NULL AND lower(cp.user_email) = ANY(v_emails))
+        OR (array_length(v_creator_ids, 1) IS NOT NULL AND cp.creator_id = ANY(v_creator_ids))
+  LOOP
+    IF v_coach.creator_id IS NOT NULL
+       AND NOT (v_coach.creator_id = ANY(v_creator_ids)) THEN
+      UPDATE public.coach_profiles
+         SET user_id = NULL, user_email = NULL
+       WHERE id = v_coach.id;
+      v_coaches_detached := v_coaches_detached || v_coach.id;
+
+    ELSIF EXISTS (
+        SELECT 1 FROM public.coach_subscriptions cs
+         WHERE cs.coach_id = v_coach.id AND cs.user_id <> p_user_id
+      ) OR EXISTS (
+        SELECT 1 FROM public.conversations c
+         WHERE c.coach_id = v_coach.id AND c.user_id <> p_user_id
+      ) THEN
+      UPDATE public.coach_profiles
+         SET user_id        = NULL,
+             user_email     = NULL,
+             listing_status = 'unlisted'
+       WHERE id = v_coach.id;
+      v_coaches_retained := v_coaches_retained || v_coach.id;
+
+    ELSE
+      -- Cascades coach_content_chunks, coach_test_messages, coach_iap_products,
+      -- coach_prompt_version_rollout, and this member's own rows against it.
+      DELETE FROM public.coach_profiles WHERE id = v_coach.id;
+      v_coaches_deleted := v_coaches_deleted || v_coach.id;
+    END IF;
+  END LOOP;
+
+  -- -------------------------------------------------------------------------
+  -- 2b. The member's own rows
+  -- -------------------------------------------------------------------------
+  /*
+    Ordered leaf-first. Every one of these would also fall out of the
+    `auth.users` cascade, but doing it here means it happens in this
+    transaction, it happens even for the legacy rows that were never linked to
+    `auth.users` at all, and the row counts are reportable.
+  */
+
+  DELETE FROM public.coach_nudges WHERE user_id = p_user_id;
+  GET DIAGNOSTICS v_n = ROW_COUNT; v_deleted := v_deleted || jsonb_build_object('coach_nudges', v_n);
+
+  DELETE FROM public.coach_visualizations WHERE user_id = p_user_id;
+  GET DIAGNOSTICS v_n = ROW_COUNT; v_deleted := v_deleted || jsonb_build_object('coach_visualizations', v_n);
+
+  DELETE FROM public.conversation_messages
+   WHERE conversation_id IN (SELECT id FROM public.conversations WHERE user_id = p_user_id);
+  GET DIAGNOSTICS v_n = ROW_COUNT; v_deleted := v_deleted || jsonb_build_object('conversation_messages', v_n);
+
+  DELETE FROM public.conversations WHERE user_id = p_user_id;
+  GET DIAGNOSTICS v_n = ROW_COUNT; v_deleted := v_deleted || jsonb_build_object('conversations', v_n);
+
+  DELETE FROM public.member_goals WHERE user_id = p_user_id;
+  GET DIAGNOSTICS v_n = ROW_COUNT; v_deleted := v_deleted || jsonb_build_object('member_goals', v_n);
+
+  -- The AFTER DELETE trigger on this table recomputes
+  -- coach_profiles.subscriber_count per row, so the roster's counts stay honest
+  -- without anything here touching them.
+  DELETE FROM public.coach_subscriptions WHERE user_id = p_user_id;
+  GET DIAGNOSTICS v_n = ROW_COUNT; v_deleted := v_deleted || jsonb_build_object('coach_subscriptions', v_n);
+
+  DELETE FROM public.push_devices WHERE user_id = p_user_id;
+  GET DIAGNOSTICS v_n = ROW_COUNT; v_deleted := v_deleted || jsonb_build_object('push_devices', v_n);
+
+  /*
+    The legacy Stripe/SMS subscription. `subscriptions.user_phone` references
+    `user_profiles(phone_number)` with no ON DELETE action at all, so leaving
+    one behind does not orphan anything — it makes the `user_profiles` delete
+    below fail outright.
+  */
+  IF array_length(v_phones, 1) IS NOT NULL THEN
+    DELETE FROM public.subscriptions WHERE user_phone = ANY(v_phones);
+    GET DIAGNOSTICS v_n = ROW_COUNT; v_deleted := v_deleted || jsonb_build_object('subscriptions', v_n);
+  ELSE
+    v_deleted := v_deleted || jsonb_build_object('subscriptions', 0);
+  END IF;
+
+  -- -------------------------------------------------------------------------
+  -- 2c. Creator profile
+  -- -------------------------------------------------------------------------
+  /*
+    `creator_profiles.user_id` is already ON DELETE SET NULL, which by itself
+    would leave the row sitting there with the person's name, bio, avatar,
+    email and payout account in it. That is not deletion.
+
+    If nothing points at it any more, it goes. If a retained coach still needs a
+    creator to be attributed to, the row survives with every personal field
+    replaced — the slug too, because slugs are usually somebody's name and they
+    appear in the public roster.
+  */
+  IF array_length(v_creator_ids, 1) IS NOT NULL THEN
+    FOR v_coach IN SELECT unnest(v_creator_ids) AS id LOOP
+      IF EXISTS (SELECT 1 FROM public.coach_profiles WHERE creator_id = v_coach.id) THEN
+        UPDATE public.creator_profiles
+           SET user_id           = NULL,
+               user_email        = 'deleted@invalid',
+               display_name      = 'Former creator',
+               -- The slug check caps the whole thing at 40 characters, so the
+               -- id is truncated; 16 hex digits is still unique in practice and
+               -- the row keeps its real id anyway.
+               slug              = 'former-creator-' || left(replace(v_coach.id::text, '-', ''), 16),
+               bio               = NULL,
+               avatar_url        = NULL,
+               website_url       = NULL,
+               social_links      = '{}'::jsonb,
+               payout_provider   = NULL,
+               payout_account_id = NULL,
+               status            = 'suspended'
+         WHERE id = v_coach.id;
+        v_creators_kept := v_creators_kept || v_coach.id;
+      ELSE
+        DELETE FROM public.creator_profiles WHERE id = v_coach.id;
+        v_creators_deleted := v_creators_deleted || v_coach.id;
+      END IF;
+    END LOOP;
+  END IF;
+
+  -- -------------------------------------------------------------------------
+  -- 2d. The profile itself
+  -- -------------------------------------------------------------------------
+  /*
+    Last, because `coach_profiles.user_email` referenced it and `subscriptions`
+    still does. `id = p_user_id` catches the rows `handle_new_user` created
+    before `user_id` existed as a column.
+  */
+  DELETE FROM public.user_profiles
+   WHERE user_id = p_user_id
+      OR id = p_user_id
+      OR (array_length(v_emails, 1) IS NOT NULL AND lower(email) = ANY(v_emails));
+  GET DIAGNOSTICS v_n = ROW_COUNT; v_deleted := v_deleted || jsonb_build_object('user_profiles', v_n);
+
+  RETURN jsonb_build_object(
+    'user_id',           p_user_id,
+    'deleted',           v_deleted,
+    'coaches_deleted',   to_jsonb(v_coaches_deleted),
+    'coaches_retained',  to_jsonb(v_coaches_retained),
+    'coaches_detached',  to_jsonb(v_coaches_detached),
+    'creators_deleted',  to_jsonb(v_creators_deleted),
+    'creators_retained', to_jsonb(v_creators_kept)
+  );
+END;
+$$;
+
+COMMENT ON FUNCTION public.delete_member_account(uuid)
+    IS 'Erases every public-schema row belonging to a member, in one transaction. The caller deletes the reference photo object first and the auth.users row afterwards. Service role only.';
+
+/*
+  Service role only, and explicitly revoked from everyone else. A member cannot
+  be allowed to call this with somebody else''s id, and the function takes the
+  id as an argument rather than reading auth.uid() precisely because its only
+  caller has no end user on the request.
+*/
+REVOKE ALL ON FUNCTION public.delete_member_account(uuid) FROM PUBLIC;
+REVOKE ALL ON FUNCTION public.delete_member_account(uuid) FROM anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.delete_member_account(uuid) TO service_role;


### PR DESCRIPTION
Closes #34.

App Store Review Guideline 5.1.1(v) requires in-app account deletion for any app that supports account creation. Cabo creates accounts two ways (Sign in with Apple, email OTP) and had no delete path, so a public submission would very likely be rejected on the first pass.

## What a member sees

**Settings → Account → Delete account**, at the top with the account it deletes rather than buried, and a screen inside the app rather than a link out to a website — Apple rejects that too.

The screen names what will be destroyed with live counts read from `/account-deletion/preview`, and gates on **typing the word DELETE**. A two-button alert is one mis-tap away from an irreversible action.

The loudest thing on it is that **this does not cancel Apple subscriptions**, because it cannot — they are held by Apple against the Apple ID, not by us — with a link straight to the App Store subscription settings. Someone who deletes their account and keeps being charged is entitled to be furious, and is an App Review risk in their own right.

## What actually happens

`functions/account-deletion`, service role, in this order and for this reason:

1. **The reference photo objects, first.** `user_profiles.reference_photo_url` can hold a photograph of the member's face. The function calls the same `deleteReferencePhotos` used by `coach-visualizer`'s likeness revocation (byte-identical vendored copy of `functions/shared/reference-photo.js`), which sweeps the whole `member-reference/<user id>/` prefix rather than the single path the column names — so a photo stored under an older extension cannot survive. The bucket sets `soft_delete_policy` retention to 0 so the bytes really go. **If this fails, nothing else happens**: an orphaned photograph of somebody who no longer has an account is worse than a deletion they have to retry. One retry, then 503 with a message they can act on.
2. **Every public-schema row**, through `delete_member_account()` — one transaction, so a half-deleted account is not a possible state: `coach_nudges`, `coach_visualizations`, `conversation_messages`, `conversations`, `member_goals`, `coach_subscriptions`, `push_devices`, the legacy `subscriptions` row, `creator_profiles`, `user_profiles`.
3. **The `auth.users` row**, through GoTrue's admin API so identities, sessions and refresh tokens go with it and the current token stops working.

### Beyond the list in the issue

Reading the schema rather than trusting the list turned up four things:

- **`coach_nudges`** also keys off `user_id` and was not in the issue's list.
- **`subscriptions`** (the legacy Stripe/SMS row) references `user_profiles(phone_number)` with *no* `ON DELETE` action, so leaving one behind does not orphan anything — it makes the `user_profiles` delete fail outright.
- **Legacy `user_profiles` rows** may be keyed by `id = auth.users.id` or by email rather than by `user_id` (`handle_new_user`, the SMS funnel). All three are matched.
- **`creator_profiles.user_id` is already `ON DELETE SET NULL`**, which by itself leaves the row sitting there with the person's name, bio, avatar, email and payout account in it. That is not deletion.

### The foreign keys that had to go first

`coach_profiles` had **both** owner links cascading:

```
user_id    uuid REFERENCES auth.users(id)      ON DELETE CASCADE
user_email text REFERENCES user_profiles(email) ON DELETE CASCADE
```

Deleting one member silently deleted every coach they owned, and each of those cascaded into other people's `coach_subscriptions`, `conversations`, `conversation_messages`, `member_goals`, `coach_content_chunks`, `coach_iap_products` and `coach_nudges` — for members paying Apple monthly for that coach.

Worse in practice: `20250531093301` seeded the five default personas against the founder's own `user_profiles` row, and `20260811090100` deliberately left `user_email` alone when it repointed their attribution at the platform creator. **The founder deleting their own account would have taken Zen Master, Gym Bro, Dance Teacher, Drill Sergeant and Frat Bro with it.**

Both are now `ON DELETE SET NULL` (and `user_email` becomes nullable, since `SET NULL` cannot fire on a `NOT NULL` column). The worst case is now an unowned coach rather than a deleted one — and `delete_member_account()` never leans on either, it decides explicitly.

### Decision: creator-owned coaches are neither deleted nor orphaned

| Case | Outcome |
| ---- | ------- |
| Attributed to another creator (the default-personas case) | **Detached.** `user_id`/`user_email` cleared; listing and attribution untouched. |
| Theirs, and other members are subscribed or have threads | **Retained and unlisted.** It keeps working for the people paying for it; nobody new can subscribe to a coach with nobody behind it. |
| Theirs, and nobody else uses it | **Deleted**, with its content chunks and store products. |

Their `creator_profiles` row is deleted if no coach still points at it, and otherwise survives with `user_id`, display name, slug, bio, avatar, links, email and payout details all replaced — the slug included, because slugs are usually somebody's name and they appear in the public roster.

Documented in `docs/multi-domain-coaches.md` § Deleting an account.

### Read paths that must not break

`get_coach_roster()` and `get_my_coaches()` both `LEFT JOIN creator_profiles`, so a scrubbed or absent creator does not drop rows. `coach_profiles.subscriber_count` stays honest because the `AFTER DELETE` trigger on `coach_subscriptions` recomputes it per row. Both are asserted on after a deletion, from the *other* member's session.

## Proving the photo is gone

`mobile/e2e/account-deletion-probe.mjs`, 64 checks, and the interesting part is how the storage claim is made rather than assumed. `@google-cloud/storage` sends every request to `STORAGE_EMULATOR_HOST` when it is set, so the probe stands up `harness/fake-gcs.mjs` — a four-endpoint stand-in for the Cloud Storage JSON API — and the **real** client issues real list and delete calls against it. The probe seeds two objects under the member's prefix (one under an older extension), and afterwards asserts:

- both objects are absent from the bucket, and nothing at all remains under the prefix;
- the client genuinely issued the deletes;
- the sweep was **by prefix**, not by the URI in the column;
- with deletes failing, the request returns 503 and the profile, the messages and the photo are all still there.

Plus: every table empty for the member, the auth identity gone, the old access token dead, signing in again a genuinely new account with no history, the retained/detached/deleted coach outcomes, the other member's threads and entitlement intact, and four ways of not confirming (no session, empty body, `"delete-it"`, `true`) that delete nothing.

## Verification

- `cd mobile && npx tsc --noEmit` — clean
- `node --check` on `functions/account-deletion/{index,reference-photo}.js` and the harness files — clean
- `cd _infra && terraform validate` — Success
- `supabase db reset` from scratch with the new migration, and a re-apply on top of an already-migrated database — both clean (idempotent)
- Probes against the local stack: `account-deletion` 64/64, `flow` 34/34, `viz-realtime` 33/33, `sms-image` 55/55, `prompt-eval/crisis` 126/126
- `rls-probe` 44 passed / 4 failed — **pre-existing on `main`**, reproduced on a `db reset` with this migration removed. The coach-detail embedded join returns `permission denied for table user_profiles` because the legacy phone-era policies (`Users can view their own coaches`) subquery `user_profiles` directly instead of going through the `SECURITY DEFINER` `owns_coach()`, and `anon` has no grant on that table. Logged under Known follow-ups rather than fixed here; the fix is to rewrite those three policies the way the newer `by uid` ones already are.

## Not in scope

Club membership (issue #34 step 5) — #31 has not landed, there are no club tables yet. The deletion is a single transaction keyed on `user_id`, so adding a club table is one `DELETE` in `delete_member_account()`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
