### PR TITLE
[security] Close the SECURITY DEFINER PUBLIC-grant class (closes #25)

### DIFF
--- a/docs/grant-matrix.md
+++ b/docs/grant-matrix.md
@@ -1,0 +1,146 @@
+# Grant matrix
+
+The intended privilege for every object in `public`, per role. This is the
+reviewable artifact issue #25 asks for: if the live schema and this table
+disagree, one of them is a bug.
+
+`REFERENCES`, `TRIGGER` and `TRUNCATE` are granted broadly by Supabase defaults
+and are omitted throughout — they are noise, not intent. Only `SELECT`,
+`INSERT`, `UPDATE`, `DELETE` and `EXECUTE` are stated.
+
+## The rule that caused this
+
+**Postgres grants `EXECUTE` on every new function to `PUBLIC` by default.** A
+`GRANT EXECUTE ... TO service_role` next to a `SECURITY DEFINER` function
+therefore excludes nobody — the function stays callable by `anon`, whose key
+ships in the web bundle and is readable by anyone who opens devtools.
+
+Every new `SECURITY DEFINER` function needs an explicit
+`REVOKE ALL ... FROM PUBLIC, anon` and *then* a deliberate grant. This is
+enforced by `security_definer_grant_audit()`, asserted in `rls-probe.mjs`, so
+the next function that forgets fails the probes rather than shipping.
+
+## Roles
+
+| Role | Who holds it |
+| --- | --- |
+| `anon` | Any unauthenticated visitor. The key is public — treat this as "the internet". |
+| `authenticated` | A signed-in member. Row scoping comes from RLS on `auth.uid()`, **not** from the grant. |
+| `service_role` | The Cloud Functions. Bypasses RLS entirely; the grant is the only control. |
+
+## Tables
+
+| Table | anon | authenticated | service_role | RLS | Notes |
+| --- | --- | --- | --- | --- | --- |
+| `coach_categories` | SELECT | SELECT | ALL | on | Public taxonomy. |
+| `coach_profiles` | SELECT | SELECT, INSERT, UPDATE, DELETE | ALL | on | Anon sees listed+active rows only, via policy. |
+| `coach_iap_products` | SELECT | SELECT | ALL | on | Prices are public; the roster shows them logged-out. |
+| `creator_profiles` | SELECT *(7 columns)* | SELECT, INSERT, UPDATE | ALL | on | Column-scoped for anon: `id, slug, display_name, bio, avatar_url, website_url, social_links`. Payout and revenue-share columns are **not** among them. |
+| `coach_content_chunks` | — | ALL | ALL | on | Creator-authored source material. |
+| `coach_test_messages` | — | ALL | ALL | on | Builder scratch space. |
+| `coach_subscriptions` | — | SELECT, INSERT, UPDATE | ALL | on | Entitlement rows. `UPDATE` is narrowed by `protect_subscription_billing_fields()`. |
+| `conversations` | — | SELECT, INSERT, UPDATE | ALL | on | |
+| `conversation_messages` | — | SELECT, INSERT | ALL | on | No UPDATE/DELETE for members: a thread is append-only. |
+| `member_goals` | — | ALL | ALL | on | |
+| `coach_visualizations` | — | SELECT, UPDATE | ALL | on | Members do not create these; the visualiser does. |
+| `push_devices` | — | ALL | ALL | on | |
+| `coach_nudges` | — | SELECT | ALL | on | Read-only to the member; the dispatcher writes. |
+| `coach_prompt_version_rollout` | — | — | — | on | Platform-only, reached through `SECURITY DEFINER` functions. |
+| `user_profiles` | — | SELECT, UPDATE | SELECT, INSERT, UPDATE, DELETE | on | `UPDATE` is narrowed by `protect_likeness_fields()`. **Anon must never hold SELECT** — see below. |
+| `subscriptions` | — | SELECT | SELECT, INSERT, UPDATE, DELETE | on | Legacy billing table. |
+
+### Why `anon` must not hold SELECT on `user_profiles`
+
+An RLS predicate is evaluated as the **invoking** role, not the table owner. So
+a policy on table A that subqueries table B forces every reader of A to hold
+`SELECT` on B.
+
+Four legacy policies on `coach_profiles` did exactly this — they matched a coach
+to its owner by looking the caller's phone number up in `user_profiles`. Their
+mere existence made the logged-out coach detail page fail with
+`permission denied for table user_profiles`, which is what four assertions in
+`rls-probe.mjs` were failing on. The tempting fix — granting `anon` SELECT on
+`user_profiles` — would have exposed every member's email, phone number,
+timezone and reference photo URL to the internet.
+
+They were dropped instead (`20260812120000_grant_discipline_sweep.sql`). The
+uid/email policies that replaced them in the multi-domain work already cover
+owner access and touch no other table.
+
+## `SECURITY DEFINER` functions
+
+These bypass RLS by design. The grant is the entire access control.
+
+### Deliberately public
+
+| Function | Reachable by | Why it is safe |
+| --- | --- | --- |
+| `get_coach_roster(text,text,int,int)` | anon, authenticated, service_role | Reads listed+active coaches only. This is the logged-out browse. |
+| `get_coach_by_handle(text)` | anon, authenticated, service_role | Same, for a single coach. |
+
+These two are the allowlist inside `security_definer_grant_audit()`. Adding to
+that list is a deliberate act and should be argued for in the PR.
+
+### Caller-scoped — `authenticated`
+
+Bodies filter on `auth.uid()`. Granted to `authenticated`, never `anon`.
+
+`begin_goal_onboarding(uuid)`, `get_my_coaches()`, `mark_conversation_read(uuid)`,
+`open_coach_conversation(uuid)`, `register_push_device(text,text,text,text)`,
+`release_push_device(text)`, `creator_slug_available(text)`, `owns_coach(uuid)`,
+`unread_message_count(uuid)`, `has_coach_access(uuid,uuid)`,
+`get_member_context(uuid,uuid)`
+
+`has_coach_access` and `get_member_context` take a `p_user_id` rather than
+reading `auth.uid()` directly, because the Cloud Functions call them on a
+member's behalf. Both now short-circuit when `auth.uid()` is set and does not
+match `p_user_id`, so a signed-in member cannot ask about anyone else.
+`service_role` runs with `auth.uid() = NULL` and is unaffected.
+
+### Backend only — `service_role`
+
+No client role has any business calling these.
+
+`due_coach_nudges(int)`, `consume_free_message(uuid,uuid)`,
+`delete_member_account(uuid)`, `revert_prompt_version_rollout()`,
+`create_user_with_trial(text,text,text,text)`, `get_or_create_user(text,text,text)`,
+`check_subscription_access(text)`, `get_trial_days_remaining(text)`,
+`can_publish_coaches(text)`, `search_similar_content(uuid,vector,int)`,
+`security_definer_grant_audit()`
+
+### Trigger functions
+
+`handle_new_user`, `handle_updated_at`, `enforce_coach_listing_rules`,
+`protect_creator_platform_fields`, `protect_likeness_fields`,
+`protect_subscription_billing_fields`, `sync_coach_subscriber_count`,
+`touch_conversation_on_message`, `coach_profiles_refresh_search_document`
+
+Revoked from everyone. Postgres refuses a direct call of a function returning
+`trigger`, so this costs nothing; triggers fire as the table owner regardless of
+`EXECUTE` grants.
+
+## What was actually exploitable before this
+
+Verified on a from-scratch stack using only the anon key over PostgREST, then
+re-verified as `42501 permission denied` afterwards.
+
+| Function | Result as anon | Severity |
+| --- | --- | --- |
+| `due_coach_nudges(int)` | Returned another member's `user_id`, `display_name`, coach name and discipline. No `auth.uid()` filter exists in it at all — it was written as a service_role dispatcher query. | **High.** Discloses that a named person is being coached, and on what. |
+| `consume_free_message(uuid,uuid)` | Incremented `messages_used` three times over three unauthenticated calls, exhausting a member's free tier. | **Medium.** Unauthenticated write; denial of the free tier. |
+| `has_coach_access(uuid,uuid)` | Returned `true` for an arbitrary member id — and the id needed to drive it leaks from `due_coach_nudges`. | **Medium.** Entitlement oracle. |
+| `check_subscription_access(text)`, `get_trial_days_remaining(text)`, `can_publish_coaches(text)` | Answered questions about an arbitrary email address. | **Low–medium.** Subscriber-enumeration oracle. |
+| `create_user_with_trial(...)`, `get_or_create_user(...)` | Executed as anon and reached their `INSERT`. | **Medium.** Unauthenticated account-creation path. |
+| `begin_goal_onboarding`, `open_coach_conversation`, `register_push_device`, `release_push_device`, `mark_conversation_read`, `get_my_coaches`, `unread_message_count`, `owns_coach`, `creator_slug_available` | Callable, but bodies are `auth.uid()`-scoped, so they no-opped. `release_push_device` returned `204` and changed nothing. | **None observed.** Revoked anyway — "the body happens to check" is not an access control. |
+
+## Errors that read as absence
+
+The third failure mode behind #25: a `PostgREST` permission error and a
+legitimate empty result are not the same thing, and several call sites treated
+them identically. A permission failure that reads as "no consent" or "no rows"
+turns a loud failure into silent wrong behaviour.
+
+When reading through PostgREST, check `error` before trusting `data`. See
+`functions/coach-visualizer` for the instance that motivated this — the
+visualiser discarded the error from its `user_profiles` read, which reads
+exactly like "the member has not granted likeness consent".

--- a/mobile/e2e/rls-probe.mjs
+++ b/mobile/e2e/rls-probe.mjs
@@ -270,5 +270,90 @@ section('Cross-tenant isolation');
   check('another member cannot see this device', (theirDevices?.length ?? 0) === 0, JSON.stringify(theirDevices));
 }
 
+// --- grant matrix (issue #25) ----------------------------------------------
+// Negative assertions. Everything above proves the app works; this proves the
+// things that must NOT work still don't. See docs/grant-matrix.md.
+section('Grant matrix — negatives');
+{
+  // The drift detector. Fails the moment a migration adds a SECURITY DEFINER
+  // function without revoking the PUBLIC default, which is the bug behind #25.
+  const { data: drift, error: driftErr } = await admin.rpc('security_definer_grant_audit');
+  check('no SECURITY DEFINER function is callable by PUBLIC or anon',
+        !driftErr && Array.isArray(drift) && drift.length === 0,
+        driftErr?.message ?? JSON.stringify(drift));
+
+  // Backend-only functions, called with the key that ships in the web bundle.
+  // Before the sweep every one of these returned 200.
+  const backendOnly = [
+    ['due_coach_nudges',         { p_limit: 5 }],
+    ['consume_free_message',     { p_user_id: userId, p_coach_id: POCKET }],
+    ['check_subscription_access',{ p_email: 'someone@example.com' }],
+    ['get_trial_days_remaining', { p_email: 'someone@example.com' }],
+    ['can_publish_coaches',      { user_email: 'someone@example.com' }],
+    ['get_or_create_user',       { user_email: 'someone@example.com' }],
+    ['create_user_with_trial',   { p_phone: '+15550000000', p_name: 'x', p_email: 'x@example.com', p_image_preference: 'a' }],
+    ['delete_member_account',    { p_user_id: userId }],
+    ['security_definer_grant_audit', {}],
+  ];
+  for (const [fn, args] of backendOnly) {
+    const { error } = await anon.rpc(fn, args);
+    check(`anon may NOT call ${fn}()`, error?.code === '42501',
+          error ? `got ${error.code}` : 'call succeeded!');
+  }
+
+  // Caller-scoped functions are for signed-in members only.
+  for (const [fn, args] of [
+    ['register_push_device', { p_expo_token: 'ExponentPushToken[probe]', p_platform: 'ios', p_device_name: 'x', p_app_version: '1' }],
+    ['release_push_device',  { p_expo_token: 'ExponentPushToken[probe]' }],
+    ['open_coach_conversation', { p_coach_id: POCKET }],
+    ['get_my_coaches', {}],
+  ]) {
+    const { error } = await anon.rpc(fn, args);
+    check(`anon may NOT call ${fn}()`, error?.code === '42501',
+          error ? `got ${error.code}` : 'call succeeded!');
+  }
+
+  // ...but the logged-out browse must still work.
+  const { error: rosterErr } = await anon.rpc('get_coach_roster',
+    { p_category: null, p_search: null, p_limit: 5, p_offset: 0 });
+  check('anon may still call get_coach_roster()', !rosterErr, rosterErr?.message);
+
+  // Tables anon must not reach at all.
+  for (const t of ['user_profiles', 'subscriptions', 'conversation_messages',
+                   'conversations', 'member_goals', 'push_devices', 'coach_nudges']) {
+    const { data, error } = await anon.from(t).select('*').limit(1);
+    check(`anon may NOT read ${t}`, !!error || (data?.length ?? 0) === 0,
+          error ? '' : `returned ${data?.length} rows`);
+  }
+
+  // creator_profiles is column-scoped for anon: the public columns are fine,
+  // the commercial ones are not. This is the negative #25 asks for by name.
+  const { error: pubColsErr } = await anon.from('creator_profiles').select('id, slug, display_name').limit(1);
+  check('anon may read creator public columns', !pubColsErr, pubColsErr?.message);
+  for (const col of ['revenue_share_bps', 'payout_provider', 'payout_account_id']) {
+    const { error } = await anon.from('creator_profiles').select(col).limit(1);
+    check(`anon may NOT read creator_profiles.${col}`, !!error,
+          error ? '' : 'column was readable!');
+  }
+
+  // A signed-in member may ask about their own entitlement, but not anyone
+  // else's — the function takes a user id, so the grant alone is not enough.
+  const { data: selfAccess, error: selfErr } = await user.rpc('has_coach_access',
+    { p_user_id: userId, p_coach_id: POCKET });
+  check('member may ask has_coach_access about themselves', !selfErr, selfErr?.message);
+
+  const { data: svcTruth } = await admin.rpc('has_coach_access', { p_user_id: userId, p_coach_id: POCKET });
+  check('  → and the answer matches what service_role sees', selfAccess === svcTruth,
+        `member=${selfAccess} service=${svcTruth}`);
+
+  const other = createClient(URL, ANON, { auth: { persistSession: false } });
+  const otherEmail = `probe-other-${Date.now()}@example.com`;
+  await admin.auth.admin.createUser({ email: otherEmail, password: 'probe-password-123', email_confirm: true });
+  await other.auth.signInWithPassword({ email: otherEmail, password: 'probe-password-123' });
+  const { data: crossAccess } = await other.rpc('has_coach_access', { p_user_id: userId, p_coach_id: POCKET });
+  check('another member may NOT probe this member\'s entitlement', crossAccess === false,
+        `got ${crossAccess}`);
+}
+
 console.log(`\n=== ${pass} passed, ${fail} failed ===`);
 process.exit(fail > 0 ? 1 : 0);

--- a/supabase/migrations/20260812120000_grant_discipline_sweep.sql
+++ b/supabase/migrations/20260812120000_grant_discipline_sweep.sql
@@ -1,0 +1,237 @@
+-- ---------------------------------------------------------------------------
+-- Grant discipline sweep (issue #25)
+--
+-- Four agents independently hit the same class of bug: a missing, over-broad or
+-- unenforced grant. This migration closes the class rather than another
+-- instance of it.
+--
+-- The root cause is that Postgres grants EXECUTE on every new function to
+-- PUBLIC by default. A `GRANT EXECUTE ... TO service_role` sitting next to a
+-- SECURITY DEFINER function therefore excludes nobody: the function stays
+-- callable by `anon`, and `anon`'s key ships in the web bundle.
+--
+-- Verified against a from-scratch stack before this migration, using only the
+-- anon key over PostgREST:
+--
+--   * due_coach_nudges(int)        returned another member's user_id,
+--                                 display_name, coach name and discipline.
+--                                 It has no auth.uid() filter at all -- it was
+--                                 written as a service_role dispatcher query.
+--                                 This is the serious one: it discloses that a
+--                                 named person is being coached, and on what.
+--   * consume_free_message(uuid,uuid)
+--                                 incremented a member's messages_used three
+--                                 times over three unauthenticated calls,
+--                                 exhausting their free tier.
+--   * has_coach_access(uuid,uuid) returned true for an arbitrary member id --
+--                                 an entitlement oracle, and the id needed to
+--                                 drive it leaks from due_coach_nudges.
+--   * check_subscription_access(text), get_trial_days_remaining(text),
+--     can_publish_coaches(text)   answer questions about an arbitrary email.
+--
+-- Functions whose bodies are already scoped by auth.uid() (register_push_device,
+-- release_push_device, open_coach_conversation, ...) were callable but not
+-- exploitable -- release_push_device returned 204 and changed nothing. They are
+-- revoked here anyway: "the body happens to check" is not an access control.
+--
+-- Idempotent: every statement is REVOKE/GRANT/DROP ... IF EXISTS or a DO block
+-- that recomputes from catalog state, so this re-applies cleanly.
+-- ---------------------------------------------------------------------------
+
+-- ---------------------------------------------------------------------------
+-- 1. Legacy phone-based policies on coach_profiles
+--
+-- These predate the multi-domain work and match a coach to its owner by
+-- looking the caller's phone number up in user_profiles. An RLS predicate is
+-- evaluated as the *invoking* role, so their mere existence forces every
+-- reader of coach_profiles -- including anon -- to hold SELECT on
+-- user_profiles. anon does not, and must not.
+--
+-- That is why the coach detail query fails with
+-- `permission denied for table user_profiles` on a from-scratch stack: four
+-- assertions in rls-probe.mjs, all one root cause.
+--
+-- They are redundant. "Owners can {view,update,delete} coaches by uid" already
+-- match on user_id = auth.uid() OR user_email = the JWT email, and the legacy
+-- policies join through that same user_email. Dropping them removes the
+-- user_profiles dependency without narrowing owner access.
+-- ---------------------------------------------------------------------------
+
+DROP POLICY IF EXISTS "Users can view their own coaches"   ON public.coach_profiles;
+DROP POLICY IF EXISTS "Users can update their own coaches" ON public.coach_profiles;
+DROP POLICY IF EXISTS "Users can delete their own coaches" ON public.coach_profiles;
+DROP POLICY IF EXISTS "Users can create coaches"           ON public.coach_profiles;
+
+-- ---------------------------------------------------------------------------
+-- 2. Revoke the PUBLIC default from every SECURITY DEFINER function
+--
+-- Done from the catalog rather than by listing names, so a function added by a
+-- migration that forgets its REVOKE is still covered on the next deploy. The
+-- deliberate grants are re-applied in section 3; anything not named there ends
+-- up callable by nobody but its owner, which is the correct default.
+-- ---------------------------------------------------------------------------
+
+DO $$
+DECLARE
+  fn record;
+BEGIN
+  FOR fn IN
+    SELECT p.oid::regprocedure AS sig
+    FROM pg_proc p
+    JOIN pg_namespace n ON n.oid = p.pronamespace
+    LEFT JOIN pg_depend d
+           ON d.objid = p.oid
+          AND d.classid = 'pg_proc'::regclass
+          AND d.deptype = 'e'          -- extension-owned; leave alone
+    WHERE n.nspname = 'public'
+      AND p.prosecdef
+      AND d.objid IS NULL
+  LOOP
+    EXECUTE format('REVOKE ALL ON FUNCTION %s FROM PUBLIC, anon, authenticated', fn.sig);
+  END LOOP;
+END $$;
+
+-- ---------------------------------------------------------------------------
+-- 3. Deliberate grants
+--
+-- The full intended matrix lives in docs/grant-matrix.md. Anything absent from
+-- this list is intentionally callable only by its owner and service_role.
+-- ---------------------------------------------------------------------------
+
+-- 3a. Public surface. Deliberately reachable by a logged-out visitor: this is
+--     the marketing/roster path, and every one of these reads only listed,
+--     active coaches.
+GRANT EXECUTE ON FUNCTION public.get_coach_roster(text, text, integer, integer) TO anon, authenticated, service_role;
+GRANT EXECUTE ON FUNCTION public.get_coach_by_handle(text)                      TO anon, authenticated, service_role;
+
+-- 3b. Caller-scoped. Bodies filter on auth.uid(); granted to authenticated only.
+GRANT EXECUTE ON FUNCTION public.begin_goal_onboarding(uuid)                    TO authenticated;
+GRANT EXECUTE ON FUNCTION public.get_my_coaches()                               TO authenticated;
+GRANT EXECUTE ON FUNCTION public.mark_conversation_read(uuid)                   TO authenticated;
+GRANT EXECUTE ON FUNCTION public.open_coach_conversation(uuid)                  TO authenticated;
+GRANT EXECUTE ON FUNCTION public.register_push_device(text, text, text, text)   TO authenticated;
+GRANT EXECUTE ON FUNCTION public.release_push_device(text)                      TO authenticated;
+GRANT EXECUTE ON FUNCTION public.creator_slug_available(text)                   TO authenticated, service_role;
+GRANT EXECUTE ON FUNCTION public.owns_coach(uuid)                               TO authenticated, service_role;
+GRANT EXECUTE ON FUNCTION public.unread_message_count(uuid)                     TO authenticated, service_role;
+GRANT EXECUTE ON FUNCTION public.has_coach_access(uuid, uuid)                   TO authenticated, service_role;
+GRANT EXECUTE ON FUNCTION public.get_member_context(uuid, uuid)                 TO authenticated, service_role;
+
+-- 3c. Backend only. No client role has any business calling these.
+GRANT EXECUTE ON FUNCTION public.due_coach_nudges(integer)                      TO service_role;
+GRANT EXECUTE ON FUNCTION public.consume_free_message(uuid, uuid)               TO service_role;
+GRANT EXECUTE ON FUNCTION public.delete_member_account(uuid)                    TO service_role;
+GRANT EXECUTE ON FUNCTION public.revert_prompt_version_rollout()                TO service_role;
+GRANT EXECUTE ON FUNCTION public.create_user_with_trial(text, text, text, text) TO service_role;
+GRANT EXECUTE ON FUNCTION public.get_or_create_user(text, text, text)           TO service_role;
+GRANT EXECUTE ON FUNCTION public.check_subscription_access(text)                TO service_role;
+GRANT EXECUTE ON FUNCTION public.get_trial_days_remaining(text)                 TO service_role;
+GRANT EXECUTE ON FUNCTION public.can_publish_coaches(text)                      TO service_role;
+GRANT EXECUTE ON FUNCTION public.search_similar_content(uuid, vector, integer)  TO service_role;
+
+-- Trigger functions are never invoked directly -- Postgres refuses a plain
+-- SELECT of a function returning `trigger` -- so the revoke above costs
+-- nothing and is left in place without a matching grant. Triggers themselves
+-- continue to fire as the table owner regardless of EXECUTE grants.
+
+-- ---------------------------------------------------------------------------
+-- 4. has_coach_access: stop authenticated callers probing other members
+--
+-- Revoking anon closes the unauthenticated oracle, but the function still took
+-- an arbitrary p_user_id from any logged-in caller. Guard it: when there is a
+-- JWT subject, it must be asking about itself. service_role and the internal
+-- SECURITY DEFINER callers (due_coach_nudges) run with auth.uid() = NULL and
+-- are unaffected.
+-- ---------------------------------------------------------------------------
+
+CREATE OR REPLACE FUNCTION public.has_coach_access(p_user_id uuid, p_coach_id uuid)
+RETURNS boolean
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+    -- Guard only. The entitlement logic below is unchanged from
+    -- 20260810120100_creators_and_coach_subscriptions.sql; if you edit one,
+    -- edit both.
+    SELECT CASE WHEN auth.uid() IS NOT NULL AND auth.uid() <> p_user_id THEN false ELSE (
+        EXISTS (
+            SELECT 1
+            FROM public.coach_subscriptions cs
+            WHERE cs.user_id = p_user_id
+              AND cs.coach_id = p_coach_id
+              AND (
+                    -- Paid / comped: access follows the entitlement window.
+                    (cs.source <> 'free_tier'
+                      AND cs.status IN ('active', 'trialing', 'grace_period')
+                      AND (cs.current_period_end IS NULL OR cs.current_period_end > now()))
+                    -- Free tier is metered, not timed: it ends when the quota is
+                    -- burned, regardless of the 'trialing' status on the row.
+                    OR (cs.source = 'free_tier' AND cs.messages_used < cs.free_message_quota)
+                  )
+        )
+        -- A creator always has access to their own coaches.
+        OR EXISTS (
+            SELECT 1
+            FROM public.coach_profiles cp
+            JOIN public.creator_profiles cr ON cr.id = cp.creator_id
+            WHERE cp.id = p_coach_id AND cr.user_id = p_user_id
+        )
+    ) END;
+$$;
+
+REVOKE ALL ON FUNCTION public.has_coach_access(uuid, uuid) FROM PUBLIC, anon;
+GRANT EXECUTE ON FUNCTION public.has_coach_access(uuid, uuid) TO authenticated, service_role;
+
+-- ---------------------------------------------------------------------------
+-- 5. Explicit table grants for the legacy tables
+--
+-- Tables predating the multi-domain work inherited whatever the local stack
+-- happened to allow. State the intent instead.
+-- ---------------------------------------------------------------------------
+
+REVOKE ALL ON public.user_profiles FROM anon;
+REVOKE ALL ON public.subscriptions FROM anon;
+GRANT SELECT, UPDATE                 ON public.user_profiles TO authenticated;
+GRANT SELECT                         ON public.subscriptions TO authenticated;
+GRANT SELECT, INSERT, UPDATE, DELETE ON public.user_profiles TO service_role;
+GRANT SELECT, INSERT, UPDATE, DELETE ON public.subscriptions TO service_role;
+
+-- ---------------------------------------------------------------------------
+-- 6. Drift detector
+--
+-- Returns one row per SECURITY DEFINER function in `public` that PUBLIC or anon
+-- can still execute, minus a documented allowlist. rls-probe.mjs asserts this
+-- is empty, so a future migration that adds a SECURITY DEFINER function without
+-- a REVOKE fails the probes instead of shipping.
+-- ---------------------------------------------------------------------------
+
+CREATE OR REPLACE FUNCTION public.security_definer_grant_audit()
+RETURNS TABLE (function_signature text, offending_role text)
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+    SELECT p.oid::regprocedure::text, r.rolename
+    FROM pg_proc p
+    JOIN pg_namespace n ON n.oid = p.pronamespace
+    LEFT JOIN pg_depend d
+           ON d.objid = p.oid
+          AND d.classid = 'pg_proc'::regclass
+          AND d.deptype = 'e'
+    CROSS JOIN LATERAL (VALUES ('public'), ('anon')) AS r(rolename)
+    WHERE n.nspname = 'public'
+      AND p.prosecdef
+      AND d.objid IS NULL
+      AND has_function_privilege(r.rolename, p.oid, 'EXECUTE')
+      -- Deliberately public: the logged-out roster and coach detail pages.
+      AND p.oid::regprocedure::text NOT IN (
+            'get_coach_roster(text,text,integer,integer)',
+            'get_coach_by_handle(text)'
+          )
+    ORDER BY 1, 2;
+$$;
+
+REVOKE ALL ON FUNCTION public.security_definer_grant_audit() FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.security_definer_grant_audit() TO service_role;


### PR DESCRIPTION
Closes #25.

Not another instance — the class. Postgres grants `EXECUTE` on every new function to `PUBLIC` by default, so the `GRANT ... TO service_role` sitting next to a `SECURITY DEFINER` function excluded nobody.

## What was actually reachable

Verified on a from-scratch stack over PostgREST using **only the anon key** — the key that ships in the web bundle. Every one of these returned `200`:

| Function | Result as anon | Severity |
| --- | --- | --- |
| `due_coach_nudges(int)` | Returned another member's `user_id`, `display_name`, coach name and discipline. No `auth.uid()` filter exists in it at all — it was written as a service_role dispatcher query. | **High.** Discloses that a named person is being coached, and on what. |
| `consume_free_message(uuid,uuid)` | Incremented `messages_used` three times over three unauthenticated calls, exhausting a member's free tier. | **Medium.** Unauthenticated write. |
| `has_coach_access(uuid,uuid)` | Returned `true` for an arbitrary member id — and the id needed to drive it leaks from `due_coach_nudges`. | **Medium.** Entitlement oracle. |
| `check_subscription_access`, `get_trial_days_remaining`, `can_publish_coaches` | Answered for an arbitrary email. | **Low–medium.** Enumeration oracle. |
| `create_user_with_trial`, `get_or_create_user` | Executed as anon and reached their `INSERT`. | **Medium.** |

Functions whose bodies are `auth.uid()`-scoped (`release_push_device` and friends) were callable but no-opped — `release_push_device` returned `204` and changed nothing. Revoked anyway: "the body happens to check" is not an access control.

All nine now return `42501`. `get_coach_roster` still works logged-out.

## Approach

Revokes are computed **from the catalog**, not a hand-written list, so a function added by a later migration that forgets its own `REVOKE` is still covered on the next deploy. Grants are then re-applied deliberately.

`security_definer_grant_audit()` returns any `SECURITY DEFINER` function still reachable by `PUBLIC`/`anon`, minus a two-entry documented allowlist. `rls-probe.mjs` asserts it is empty, so the next one to forget fails the probes instead of shipping.

`has_coach_access` also short-circuits when `auth.uid()` is set and doesn't match `p_user_id`. Its entitlement logic is otherwise unchanged — the free-tier metering, `trialing`/`grace_period` statuses and creator-owns-their-coach branches are all preserved. (My first draft of this rewrite dropped all three; caught before it applied.)

## The four inherited probe failures

`main` was at 44/4, all four failing with `permission denied for table user_profiles` on the coach detail query.

Root cause: four **legacy phone-based policies** on `coach_profiles` that subquery `user_profiles`. An RLS predicate is evaluated as the *invoking* role, so their existence forced every reader of `coach_profiles` — including anon — to hold SELECT on `user_profiles`.

The tempting fix, granting anon SELECT on `user_profiles`, would have published every member's email, phone, timezone and reference photo URL. Dropped the policies instead; they're redundant with the uid/email policies the multi-domain work added.

## Verification

- `rls-probe.mjs` **44/4 → 77/0**, with 29 new negative assertions: per-function `42501` checks, per-table anon denials, `creator_profiles` payout columns unreadable by anon, and cross-member entitlement probing blocked.
- Other suites unchanged and green: flow 46/0, viz-realtime 33/0, sms-image 55/0, account-deletion 64/0. **275 checks total.**
- Migration is idempotent (re-applies clean) and the full chain cold-applies against `supabase-shim.sql` with `ON_ERROR_STOP=1`.
- `tsc --noEmit` clean, `node --check` clean on every function, `terraform validate` passes.

## Note for the next agent

`viz-realtime-probe.mjs` is **flaky** — it failed 29/4 on the first run and passed 33/0 on a re-run with no changes in between. The failures are all "the message arrived over realtime — received 0", i.e. the websocket subscription hadn't established before the assertion. Worth a retry/wait rather than an hour of debugging.

`docs/grant-matrix.md` is the reviewable per-role-per-object table #25 asks for.

🤖 Generated with [Claude Code](https://claude.com/claude-code)