### PR TITLE
[club] Clubs as a first-class entity: seats, comped entitlements, invites (closes #31)

### DIFF
--- a/docs/grant-matrix.md
+++ b/docs/grant-matrix.md
@@ -48,6 +48,9 @@ the next function that forgets fails the probes rather than shipping.
 | `coach_prompt_version_rollout` | — | — | — | on | Platform-only, reached through `SECURITY DEFINER` functions. |
 | `user_profiles` | — | SELECT, UPDATE | SELECT, INSERT, UPDATE, DELETE | on | `UPDATE` is narrowed by `protect_likeness_fields()`. **Anon must never hold SELECT** — see below. |
 | `subscriptions` | — | SELECT | SELECT, INSERT, UPDATE, DELETE | on | Legacy billing table. |
+| `clubs` | — | SELECT *(6 columns)*, UPDATE *(name, slug)* | ALL | on | Column-scoped: `id, slug, name, status, creator_id, created_at`. The commercial columns (`seats`, `plan`, `billing_email`, `external_billing_ref`, `notes`) are **not granted to `authenticated` at all** — an owner reads them through `club_billing()`. A policy mistake therefore cannot leak them. |
+| `club_members` | — | SELECT | ALL | on | Policy: own row, or any row if `is_club_owner()`. A member must not be able to enumerate the squad. |
+| `club_coaches` | — | SELECT | ALL | on | Visible to members of that club. |
 
 ### Why `anon` must not hold SELECT on `user_profiles`
 
@@ -89,7 +92,19 @@ Bodies filter on `auth.uid()`. Granted to `authenticated`, never `anon`.
 `open_coach_conversation(uuid)`, `register_push_device(text,text,text,text)`,
 `release_push_device(text)`, `creator_slug_available(text)`, `owns_coach(uuid)`,
 `unread_message_count(uuid)`, `has_coach_access(uuid,uuid)`,
-`get_member_context(uuid,uuid)`
+`get_member_context(uuid,uuid)`, `is_club_owner(uuid)`, `is_club_member(uuid)`,
+`club_roster(uuid)`, `club_billing(uuid)`
+
+`is_club_owner` / `is_club_member` are `SECURITY DEFINER` for a structural
+reason, not convenience: the RLS policies on `club_members` need to ask "is the
+caller an owner of this club", which is itself a question about `club_members`.
+Asking it through a policy-bound query recurses. Reading the table with RLS
+bypassed breaks the cycle.
+
+`club_roster` and `club_billing` are granted to `authenticated` but each embeds
+`is_club_owner(p_club_id)` in its own `WHERE`, so a non-owner gets zero rows
+rather than an error. That is deliberate: it means an owner of club A probing
+club B learns nothing about whether club B exists.
 
 `has_coach_access` and `get_member_context` take a `p_user_id` rather than
 reading `auth.uid()` directly, because the Cloud Functions call them on a
@@ -106,7 +121,13 @@ No client role has any business calling these.
 `create_user_with_trial(text,text,text,text)`, `get_or_create_user(text,text,text)`,
 `check_subscription_access(text)`, `get_trial_days_remaining(text)`,
 `can_publish_coaches(text)`, `search_similar_content(uuid,vector,int)`,
-`security_definer_grant_audit()`
+`security_definer_grant_audit()`, `club_add_members(uuid,text[])`,
+`grant_club_seat(uuid,uuid,uuid)`, `revoke_club_seats(uuid,uuid)`
+
+Seat granting is backend-only on purpose. If `grant_club_seat` were reachable by
+`authenticated`, any signed-in member could mint themselves a comped entitlement
+to any coach — the entitlement system's own bypass. `club-probe.mjs` asserts
+both `anon` and a signed-in member get `42501` from all three.
 
 ### Trigger functions
 

--- a/mobile/e2e/README.md
+++ b/mobile/e2e/README.md
@@ -10,6 +10,7 @@ and through the Cloud Functions over HTTP.
 | `flow-probe.mjs` | Goal intake, prompt v1/v2 selection, free-tier metering, the 402 paywall, entitlement restore, coach-initiated nudges, `suppressUserTurn` auth, the nudge dispatcher sweep |
 | `viz-realtime-probe.mjs` | Visualiser guards (`no_aspiration`, entitlement, daily limit), prompt hygiene, likeness consent and reference photos, and realtime delivery of a coach-initiated message |
 | `sms-image-probe.mjs` | The daily SMS image job across three disciplines: channel scoping, coach resolution, goal-driven prompts, likeness consent, and that no member can receive fitness before/after imagery |
+| `club-probe.mjs` | Clubs: seats granted through `coach_subscriptions` so `has_coach_access()` stays the only gate, the invite-on-signup path, revocation by removal / deletion / club lapse, and the negatives — a member cannot enumerate the squad, read what the club pays, or mint themselves a seat |
 | `account-deletion-probe.mjs` | Account deletion: that no row in any affected table survives, that the reference photo **object** is gone from the bucket, what happens to coaches the member created and to the people subscribed to them, and that a photo we cannot delete stops the whole deletion |
 
 ## Setting up a local stack
@@ -68,6 +69,7 @@ persistence, metering and auth, not the model's prose.
 ```sh
 cd mobile
 ENV_FILE=/tmp/cabo-local/local.env node e2e/rls-probe.mjs
+ENV_FILE=/tmp/cabo-local/local.env node e2e/club-probe.mjs
 ENV_FILE=/tmp/cabo-local/local.env node e2e/flow-probe.mjs
 ENV_FILE=/tmp/cabo-local/local.env node e2e/viz-realtime-probe.mjs
 ENV_FILE=/tmp/cabo-local/local.env node e2e/sms-image-probe.mjs

--- a/mobile/e2e/club-probe.mjs
+++ b/mobile/e2e/club-probe.mjs
@@ -1,0 +1,310 @@
+/**
+ * Clubs (issue #31): seats, comped entitlements, invites and revocation.
+ *
+ * Creates its own club, coach, creator and members and removes all of them
+ * afterwards, including on failure, because the other suites assert on the
+ * exact contents of the seeded roster.
+ *
+ * The load-bearing assertions are the negative ones. A club owner buying access
+ * for a squad must not become a way to enumerate who is in that squad, or to
+ * read what the club pays.
+ */
+import { createClient } from '@supabase/supabase-js';
+import fs from 'node:fs';
+
+const env = Object.fromEntries(
+  fs.readFileSync(process.env.ENV_FILE, 'utf8')
+    .split('\n').filter(Boolean)
+    .map((line) => {
+      const i = line.indexOf('=');
+      return [line.slice(0, i), line.slice(i + 1).replace(/^"|"$/g, '')];
+    })
+);
+
+const URL = env.API_URL;
+const ANON = env.ANON_KEY;
+const SERVICE = env.SERVICE_ROLE_KEY;
+
+const admin = createClient(URL, SERVICE, { auth: { persistSession: false } });
+const anon = createClient(URL, ANON, { auth: { persistSession: false } });
+
+let pass = 0, fail = 0;
+function check(name, ok, detail = '') {
+  if (ok) { pass++; console.log(`  ok    ${name}`); }
+  else { fail++; console.log(`  FAIL  ${name}${detail ? ` — ${detail}` : ''}`); }
+}
+function section(t) { console.log(`\n### ${t}`); }
+
+const stamp = Date.now();
+const created = { users: [], clubs: [], coaches: [], creators: [] };
+
+async function signIn(email) {
+  const c = createClient(URL, ANON, { auth: { persistSession: false } });
+  const { error } = await c.auth.signInWithPassword({ email, password: 'probe-password-123' });
+  if (error) throw new Error(`sign in ${email}: ${error.message}`);
+  return c;
+}
+
+async function makeUser(email) {
+  const { data, error } = await admin.auth.admin.createUser({
+    email, password: 'probe-password-123', email_confirm: true,
+  });
+  if (error) throw new Error(`createUser ${email}: ${error.message}`);
+  created.users.push(data.user.id);
+  return data.user.id;
+}
+
+async function cleanup() {
+  for (const id of created.clubs)   await admin.from('clubs').delete().eq('id', id);
+  for (const id of created.coaches) await admin.from('coach_profiles').delete().eq('id', id);
+  for (const id of created.creators) await admin.from('creator_profiles').delete().eq('id', id);
+  for (const id of created.users)   await admin.auth.admin.deleteUser(id).catch(() => {});
+}
+
+try {
+  // --- fixtures -------------------------------------------------------------
+  section('Fixtures: a club, a head coach, an owner');
+
+  const ownerId = await makeUser(`club-owner-${stamp}@example.com`);
+
+  const { data: creator, error: creatorErr } = await admin.from('creator_profiles').insert({
+    user_id: ownerId, user_email: `club-owner-${stamp}@example.com`,
+    display_name: 'Northside Athletic', slug: `northside-${stamp}`, status: 'approved',
+  }).select('id').single();
+  check('creator row for the club', !creatorErr && !!creator, creatorErr?.message);
+  created.creators.push(creator.id);
+
+  const { data: coach, error: coachErr } = await admin.from('coach_profiles').insert({
+    name: 'Coach Ada', creator_id: creator.id, discipline: 'Middle-distance running',
+    primary_response_style: 'wise_mentor',
+    active: true, listing_status: 'listed', public: false,
+    user_email: `club-owner-${stamp}@example.com`,
+  }).select('id').single();
+  check('club coach', !coachErr && !!coach, coachErr?.message);
+  created.coaches.push(coach.id);
+
+  const { data: club, error: clubErr } = await admin.from('clubs').insert({
+    slug: `northside-ac-${stamp}`, name: 'Northside AC', creator_id: creator.id,
+    seats: 12, plan: 'pilot', billing_email: `billing-${stamp}@example.com`,
+  }).select('id').single();
+  check('club created', !clubErr && !!club, clubErr?.message);
+  created.clubs.push(club.id);
+
+  await admin.from('club_coaches').insert({ club_id: club.id, coach_id: coach.id });
+  await admin.from('club_members').insert({
+    club_id: club.id, user_id: ownerId, invited_email: `club-owner-${stamp}@example.com`,
+    role: 'owner', status: 'active', joined_at: new Date().toISOString(),
+  });
+  check('coach attached and owner seated', true);
+
+  // --- ten members in one action -------------------------------------------
+  section('Ten members added and granted access in one action');
+
+  const memberEmails = [];
+  const uidByEmail = new Map();
+  for (let i = 0; i < 6; i++) {
+    const e = `club-member-${i}-${stamp}@example.com`;
+    uidByEmail.set(e, await makeUser(e));
+    memberEmails.push(e);
+  }
+  // Four who have not signed up yet — the invite path.
+  const inviteEmails = [];
+  for (let i = 6; i < 10; i++) inviteEmails.push(`club-invitee-${i}-${stamp}@example.com`);
+
+  const { data: addResult, error: addErr } = await admin.rpc('club_add_members', {
+    p_club_id: club.id, p_emails: [...memberEmails, ...inviteEmails],
+  });
+  const r = Array.isArray(addResult) ? addResult[0] : addResult;
+  check('club_add_members in one call', !addErr, addErr?.message);
+  check('  → 6 existing accounts granted', r?.granted === 6, JSON.stringify(r));
+  check('  → 4 invited pending signup', r?.invited === 4, JSON.stringify(r));
+
+  let allAccess = true;
+  for (const e of memberEmails) {
+    const { data: ok } = await admin.rpc('has_coach_access',
+      { p_user_id: uidByEmail.get(e), p_coach_id: coach.id });
+    if (!ok) allAccess = false;
+  }
+  check('every granted member passes has_coach_access()', allAccess);
+
+  const { data: seatRows } = await admin.from('coach_subscriptions')
+    .select('user_id, source, status, club_id').eq('club_id', club.id);
+  check('  → seats are coach_subscriptions rows, not a parallel mechanism',
+        seatRows?.length === 6 && seatRows.every(s => s.source === 'creator_comp' && s.status === 'active'),
+        JSON.stringify(seatRows?.length));
+
+  // --- invite claim ---------------------------------------------------------
+  section('An invited member signs up');
+  const inviteeId = await makeUser(inviteEmails[0]);
+  const { data: inviteeAccess } = await admin.rpc('has_coach_access', {
+    p_user_id: inviteeId, p_coach_id: coach.id,
+  });
+  check('signing up claims the invite and grants the seat', inviteeAccess === true);
+
+  const { data: claimed } = await admin.from('club_members')
+    .select('status, user_id').eq('club_id', club.id).eq('invited_email', inviteEmails[0]).single();
+  check('  → membership row linked and activated',
+        claimed?.status === 'active' && claimed?.user_id === inviteeId, JSON.stringify(claimed));
+
+  // --- revocation -----------------------------------------------------------
+  section('Removing a member revokes access immediately');
+  const victimEmail = memberEmails[0];
+  const { data: victimRow } = await admin.from('club_members')
+    .select('id, user_id').eq('club_id', club.id).eq('invited_email', victimEmail).single();
+
+  const { data: beforeRevoke } = await admin.rpc('has_coach_access', {
+    p_user_id: victimRow.user_id, p_coach_id: coach.id,
+  });
+  check('member has access before removal', beforeRevoke === true);
+
+  await admin.from('club_members').update({ status: 'removed' }).eq('id', victimRow.id);
+
+  const { data: afterRevoke } = await admin.rpc('has_coach_access', {
+    p_user_id: victimRow.user_id, p_coach_id: coach.id,
+  });
+  check('has_coach_access() is false the moment they are removed', afterRevoke === false,
+        `got ${afterRevoke}`);
+
+  const { data: revokedRow } = await admin.from('coach_subscriptions')
+    .select('status').eq('user_id', victimRow.user_id).eq('coach_id', coach.id).single();
+  check('  → the entitlement row is revoked, not deleted', revokedRow?.status === 'revoked',
+        JSON.stringify(revokedRow));
+
+  // Deleting the membership row outright must revoke too.
+  const { data: victim2 } = await admin.from('club_members')
+    .select('id, user_id').eq('club_id', club.id).eq('invited_email', memberEmails[1]).single();
+  await admin.from('club_members').delete().eq('id', victim2.id);
+  const { data: afterDelete } = await admin.rpc('has_coach_access', {
+    p_user_id: victim2.user_id, p_coach_id: coach.id,
+  });
+  check('deleting the membership row revokes too (no back door)', afterDelete === false,
+        `got ${afterDelete}`);
+
+  // --- a paid subscription must survive ------------------------------------
+  section('A club seat must not clobber a subscription the member paid for');
+  const payerEmail = memberEmails[2];
+  const { data: payerRow } = await admin.from('club_members')
+    .select('user_id').eq('club_id', club.id).eq('invited_email', payerEmail).single();
+  await admin.from('coach_subscriptions').update({
+    source: 'apple_iap', status: 'active', original_transaction_id: 'txn-probe-1', club_id: null,
+  }).eq('user_id', payerRow.user_id).eq('coach_id', coach.id);
+
+  await admin.rpc('club_add_members', { p_club_id: club.id, p_emails: [payerEmail] });
+  const { data: paidAfter } = await admin.from('coach_subscriptions')
+    .select('source, club_id').eq('user_id', payerRow.user_id).eq('coach_id', coach.id).single();
+  check('re-granting leaves the paid row alone', paidAfter?.source === 'apple_iap',
+        JSON.stringify(paidAfter));
+  check('  → and does not mark it club-granted (so revocation cannot cancel it)',
+        paidAfter?.club_id === null, JSON.stringify(paidAfter));
+
+  // --- what a member may and may not see ------------------------------------
+  section('A member may not enumerate the squad');
+  const memberClient = await signIn(memberEmails[3]);
+  const { data: memberRow } = await admin.from('club_members')
+    .select('user_id').eq('club_id', club.id).eq('invited_email', memberEmails[3]).single();
+
+  const { data: visibleMembers } = await memberClient.from('club_members').select('id, user_id');
+  check('member sees only their own membership row',
+        visibleMembers?.length === 1 && visibleMembers[0].user_id === memberRow.user_id,
+        `saw ${visibleMembers?.length} rows`);
+
+  const { data: visibleClub } = await memberClient.from('clubs').select('id, name, slug');
+  check('member may see the club they belong to', visibleClub?.length === 1, JSON.stringify(visibleClub));
+
+  for (const col of ['seats', 'plan', 'billing_email', 'external_billing_ref']) {
+    const { error } = await memberClient.from('clubs').select(col).limit(1);
+    check(`member may NOT read clubs.${col}`, !!error, error ? '' : 'column was readable!');
+  }
+
+  const { data: memberBilling } = await memberClient.rpc('club_billing', { p_club_id: club.id });
+  check('club_billing() returns nothing to a member', (memberBilling?.length ?? 0) === 0,
+        JSON.stringify(memberBilling));
+
+  const { data: memberRoster } = await memberClient.rpc('club_roster', { p_club_id: club.id });
+  check('club_roster() returns nothing to a member', (memberRoster?.length ?? 0) === 0,
+        JSON.stringify(memberRoster));
+
+  // --- what the owner may see -----------------------------------------------
+  section('The owner may see their own club, and only their own');
+  const ownerClient = await signIn(`club-owner-${stamp}@example.com`);
+
+  const { data: ownerRoster } = await ownerClient.rpc('club_roster', { p_club_id: club.id });
+  check('owner reads the roster', (ownerRoster?.length ?? 0) >= 8, `got ${ownerRoster?.length}`);
+  check('  → roster carries no conversation content',
+        ownerRoster?.every(m => !('content' in m) && !('goal' in m)), JSON.stringify(Object.keys(ownerRoster?.[0] ?? {})));
+
+  const { data: ownerBilling } = await ownerClient.rpc('club_billing', { p_club_id: club.id });
+  check('owner reads billing', ownerBilling?.[0]?.plan === 'pilot', JSON.stringify(ownerBilling));
+
+  // A second club, to prove cross-club isolation.
+  const { data: club2 } = await admin.from('clubs').insert({
+    slug: `southside-${stamp}`, name: 'Southside AC', seats: 5, plan: 'pilot',
+    billing_email: `other-${stamp}@example.com`,
+  }).select('id').single();
+  created.clubs.push(club2.id);
+
+  const { data: crossRoster } = await ownerClient.rpc('club_roster', { p_club_id: club2.id });
+  check('owner of club A cannot read club B roster', (crossRoster?.length ?? 0) === 0,
+        JSON.stringify(crossRoster));
+  const { data: crossBilling } = await ownerClient.rpc('club_billing', { p_club_id: club2.id });
+  check('owner of club A cannot read club B billing', (crossBilling?.length ?? 0) === 0,
+        JSON.stringify(crossBilling));
+  const { data: crossClub } = await ownerClient.from('clubs').select('id').eq('id', club2.id);
+  check('owner of club A cannot even see club B', (crossClub?.length ?? 0) === 0,
+        JSON.stringify(crossClub));
+
+  // --- club lapses ----------------------------------------------------------
+  section('A club that lapses revokes every seat');
+  const { data: stillActive } = await admin.from('coach_subscriptions')
+    .select('user_id').eq('club_id', club.id).eq('status', 'active');
+  check('seats active before the lapse', (stillActive?.length ?? 0) > 0, `${stillActive?.length}`);
+
+  await admin.from('clubs').update({ status: 'lapsed' }).eq('id', club.id);
+
+  const { data: afterLapse } = await admin.from('coach_subscriptions')
+    .select('user_id').eq('club_id', club.id).eq('status', 'active');
+  check('no club-granted seat survives the lapse', (afterLapse?.length ?? 0) === 0,
+        `${afterLapse?.length} still active`);
+
+  const { data: lapsedAccess } = await admin.rpc('has_coach_access', {
+    p_user_id: memberRow.user_id, p_coach_id: coach.id,
+  });
+  check('  → and has_coach_access() agrees', lapsedAccess === false, `got ${lapsedAccess}`);
+
+  // --- anon ------------------------------------------------------------------
+  section('Grant matrix — clubs are invisible to anon');
+  for (const t of ['clubs', 'club_members', 'club_coaches']) {
+    const { data, error } = await anon.from(t).select('*').limit(1);
+    check(`anon may NOT read ${t}`, !!error || (data?.length ?? 0) === 0,
+          error ? '' : `returned ${data?.length} rows`);
+  }
+  for (const [fn, args] of [
+    ['club_add_members', { p_club_id: club.id, p_emails: ['x@example.com'] }],
+    ['club_roster',      { p_club_id: club.id }],
+    ['club_billing',     { p_club_id: club.id }],
+    ['grant_club_seat',  { p_club_id: club.id, p_user_id: ownerId, p_coach_id: coach.id }],
+    ['revoke_club_seats',{ p_club_id: club.id, p_user_id: ownerId }],
+    ['is_club_owner',    { p_club_id: club.id }],
+  ]) {
+    const { error } = await anon.rpc(fn, args);
+    check(`anon may NOT call ${fn}()`, error?.code === '42501', error ? `got ${error.code}` : 'call succeeded!');
+  }
+
+  // A signed-in member must not be able to mint themselves a seat.
+  for (const [fn, args] of [
+    ['grant_club_seat',   { p_club_id: club.id, p_user_id: memberRow.user_id, p_coach_id: coach.id }],
+    ['club_add_members',  { p_club_id: club.id, p_emails: ['x@example.com'] }],
+    ['revoke_club_seats', { p_club_id: club.id, p_user_id: ownerId }],
+  ]) {
+    const { error } = await memberClient.rpc(fn, args);
+    check(`a member may NOT call ${fn}()`, error?.code === '42501',
+          error ? `got ${error.code}` : 'call succeeded!');
+  }
+} catch (err) {
+  check(`probe threw: ${err.message}`, false);
+} finally {
+  await cleanup();
+}
+
+console.log(`\n=== ${pass} passed, ${fail} failed ===`);
+process.exit(fail > 0 ? 1 : 0);

--- a/supabase/migrations/20260812130000_clubs.sql
+++ b/supabase/migrations/20260812130000_clubs.sql
@@ -1,0 +1,457 @@
+-- ---------------------------------------------------------------------------
+-- Clubs as a first-class entity (issue #31)
+--
+-- The go-to-market moved from individual creators to clubs, academies and
+-- studios: one head coach whose expertise is rationed across 60-200 members.
+-- The org supplies both the coach and the members.
+--
+-- Shape: a new `clubs` table rather than a flag on `creator_profiles`.
+-- creator_profiles models a *seller* -- it carries revenue_share_bps,
+-- payout_provider and payout_account_id, all protected by
+-- protect_creator_platform_fields(). A club is a *buyer*. Overloading the row
+-- would leave those three columns meaning nothing-or-something depending on a
+-- flag, and every creator query would grow a "but is it a club" branch. A club
+-- still owns coaches, so it points at a creator_profiles row via creator_id
+-- rather than becoming one.
+--
+-- Entitlement deliberately does NOT get a second mechanism. Seats are issued as
+-- `coach_subscriptions` rows with source = 'creator_comp', so has_coach_access()
+-- remains the single gate every read path already calls. What is new is
+-- `coach_subscriptions.club_id`, which records that a seat came from a club so
+-- revocation can find exactly those rows and nothing else.
+--
+-- Grants follow docs/grant-matrix.md: every SECURITY DEFINER function here is
+-- revoked from PUBLIC and anon before any deliberate grant. See #25.
+-- ---------------------------------------------------------------------------
+
+-- ---------------------------------------------------------------------------
+-- 1. Tables
+-- ---------------------------------------------------------------------------
+
+CREATE TABLE IF NOT EXISTS public.clubs (
+    id                  uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    created_at          timestamptz NOT NULL DEFAULT now(),
+    updated_at          timestamptz NOT NULL DEFAULT now(),
+    slug                text NOT NULL UNIQUE,
+    name                text NOT NULL,
+    -- The creator whose coaches this club offers its members.
+    creator_id          uuid REFERENCES public.creator_profiles(id) ON DELETE SET NULL,
+    status              text NOT NULL DEFAULT 'active'
+                        CHECK (status IN ('active', 'lapsed', 'suspended')),
+    -- Commercial columns. authenticated is never granted SELECT on these; an
+    -- owner reads them through club_billing(), which checks ownership. A member
+    -- must not be able to see what their club pays.
+    seats               integer NOT NULL DEFAULT 0 CHECK (seats >= 0),
+    plan                text,
+    billing_email       text,
+    external_billing_ref text,
+    notes               text
+);
+
+COMMENT ON TABLE public.clubs IS
+    'An organisation that buys coach access on behalf of its members';
+COMMENT ON COLUMN public.clubs.creator_id IS
+    'The creator row whose coaches this club offers. A club owns coaches; it is not itself a seller.';
+
+CREATE TABLE IF NOT EXISTS public.club_members (
+    id            uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    created_at    timestamptz NOT NULL DEFAULT now(),
+    updated_at    timestamptz NOT NULL DEFAULT now(),
+    club_id       uuid NOT NULL REFERENCES public.clubs(id) ON DELETE CASCADE,
+    -- NULL until an invited person actually signs up. The invite is keyed on
+    -- email; claim_club_invites() links it on account creation.
+    user_id       uuid REFERENCES auth.users(id) ON DELETE CASCADE,
+    invited_email text,
+    role          text NOT NULL DEFAULT 'member'
+                  CHECK (role IN ('owner', 'coach', 'member')),
+    status        text NOT NULL DEFAULT 'invited'
+                  CHECK (status IN ('invited', 'active', 'removed')),
+    invited_at    timestamptz NOT NULL DEFAULT now(),
+    joined_at     timestamptz,
+    removed_at    timestamptz,
+    CONSTRAINT club_member_identified CHECK (user_id IS NOT NULL OR invited_email IS NOT NULL)
+);
+
+-- One membership per person per club, counting invited-but-not-yet-signed-up
+-- separately since user_id is still null there.
+CREATE UNIQUE INDEX IF NOT EXISTS club_members_club_user_uniq
+    ON public.club_members (club_id, user_id) WHERE user_id IS NOT NULL;
+CREATE UNIQUE INDEX IF NOT EXISTS club_members_club_email_uniq
+    ON public.club_members (club_id, lower(invited_email)) WHERE user_id IS NULL;
+CREATE INDEX IF NOT EXISTS club_members_user_idx ON public.club_members (user_id);
+
+-- Which coaches a club offers. Explicit rather than "every coach the creator
+-- owns", so a club can pilot with one coach without exposing the rest.
+CREATE TABLE IF NOT EXISTS public.club_coaches (
+    club_id    uuid NOT NULL REFERENCES public.clubs(id) ON DELETE CASCADE,
+    coach_id   uuid NOT NULL REFERENCES public.coach_profiles(id) ON DELETE CASCADE,
+    created_at timestamptz NOT NULL DEFAULT now(),
+    PRIMARY KEY (club_id, coach_id)
+);
+
+-- Marks a seat as club-granted. Revocation targets exactly these rows.
+ALTER TABLE public.coach_subscriptions
+    ADD COLUMN IF NOT EXISTS club_id uuid REFERENCES public.clubs(id) ON DELETE SET NULL;
+CREATE INDEX IF NOT EXISTS coach_subscriptions_club_idx
+    ON public.coach_subscriptions (club_id) WHERE club_id IS NOT NULL;
+
+DROP TRIGGER IF EXISTS clubs_updated_at ON public.clubs;
+CREATE TRIGGER clubs_updated_at BEFORE UPDATE ON public.clubs
+    FOR EACH ROW EXECUTE FUNCTION public.handle_updated_at();
+DROP TRIGGER IF EXISTS club_members_updated_at ON public.club_members;
+CREATE TRIGGER club_members_updated_at BEFORE UPDATE ON public.club_members
+    FOR EACH ROW EXECUTE FUNCTION public.handle_updated_at();
+
+-- ---------------------------------------------------------------------------
+-- 2. Membership predicates
+--
+-- Both are SECURITY DEFINER for a specific reason: the RLS policies on
+-- club_members need to ask "is the caller an owner of this club", which is
+-- itself a question about club_members. Asking it through a policy-bound query
+-- recurses. A SECURITY DEFINER function reads the table with RLS bypassed and
+-- breaks the cycle.
+-- ---------------------------------------------------------------------------
+
+CREATE OR REPLACE FUNCTION public.is_club_owner(p_club_id uuid)
+RETURNS boolean
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+    SELECT EXISTS (
+        SELECT 1 FROM public.club_members m
+        WHERE m.club_id = p_club_id
+          AND m.user_id = auth.uid()
+          AND m.role IN ('owner', 'coach')
+          AND m.status = 'active'
+    );
+$$;
+
+CREATE OR REPLACE FUNCTION public.is_club_member(p_club_id uuid)
+RETURNS boolean
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+    SELECT EXISTS (
+        SELECT 1 FROM public.club_members m
+        WHERE m.club_id = p_club_id
+          AND m.user_id = auth.uid()
+          AND m.status = 'active'
+    );
+$$;
+
+REVOKE ALL ON FUNCTION public.is_club_owner(uuid)  FROM PUBLIC, anon;
+REVOKE ALL ON FUNCTION public.is_club_member(uuid) FROM PUBLIC, anon;
+GRANT EXECUTE ON FUNCTION public.is_club_owner(uuid)  TO authenticated, service_role;
+GRANT EXECUTE ON FUNCTION public.is_club_member(uuid) TO authenticated, service_role;
+
+-- ---------------------------------------------------------------------------
+-- 3. Seat granting and revocation
+--
+-- The awkward case, handled explicitly: a member may already be paying for the
+-- same coach out of their own pocket. A club seat must never overwrite a paid
+-- entitlement, because revoking the seat later would then cancel a subscription
+-- the member bought. So the upsert only takes over rows that are free_tier or
+-- already club-granted, and leaves apple_iap / google_play / stripe rows alone.
+-- ---------------------------------------------------------------------------
+
+CREATE OR REPLACE FUNCTION public.grant_club_seat(p_club_id uuid, p_user_id uuid, p_coach_id uuid)
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+BEGIN
+    INSERT INTO public.coach_subscriptions
+        (user_id, coach_id, status, source, club_id, started_at, current_period_end)
+    VALUES
+        (p_user_id, p_coach_id, 'active', 'creator_comp', p_club_id, now(), NULL)
+    ON CONFLICT (user_id, coach_id) DO UPDATE
+        SET status             = 'active',
+            source             = 'creator_comp',
+            club_id            = EXCLUDED.club_id,
+            current_period_end = NULL,
+            updated_at         = now()
+        WHERE public.coach_subscriptions.source IN ('free_tier', 'creator_comp', 'promo');
+END;
+$$;
+
+-- Revoke every seat this club granted to this member. Used by the triggers
+-- below; never leaves a removed member able to keep talking.
+CREATE OR REPLACE FUNCTION public.revoke_club_seats(p_club_id uuid, p_user_id uuid DEFAULT NULL)
+RETURNS integer
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+    v_count integer;
+BEGIN
+    UPDATE public.coach_subscriptions
+       SET status = 'revoked', updated_at = now()
+     WHERE club_id = p_club_id
+       AND (p_user_id IS NULL OR user_id = p_user_id)
+       AND status <> 'revoked';
+    GET DIAGNOSTICS v_count = ROW_COUNT;
+    RETURN v_count;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.grant_club_seat(uuid, uuid, uuid)  FROM PUBLIC, anon, authenticated;
+REVOKE ALL ON FUNCTION public.revoke_club_seats(uuid, uuid)      FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.grant_club_seat(uuid, uuid, uuid) TO service_role;
+GRANT EXECUTE ON FUNCTION public.revoke_club_seats(uuid, uuid)     TO service_role;
+
+-- 3a. Removing a member revokes their seats, immediately and by any path --
+--     a status flip, or an outright DELETE of the membership row.
+CREATE OR REPLACE FUNCTION public.club_membership_revocation()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+BEGIN
+    IF TG_OP = 'DELETE' THEN
+        IF OLD.user_id IS NOT NULL THEN
+            PERFORM public.revoke_club_seats(OLD.club_id, OLD.user_id);
+        END IF;
+        RETURN OLD;
+    END IF;
+
+    IF NEW.status = 'removed' AND OLD.status <> 'removed' AND NEW.user_id IS NOT NULL THEN
+        PERFORM public.revoke_club_seats(NEW.club_id, NEW.user_id);
+        NEW.removed_at := COALESCE(NEW.removed_at, now());
+    END IF;
+    RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS club_members_revoke ON public.club_members;
+CREATE TRIGGER club_members_revoke
+    BEFORE UPDATE ON public.club_members
+    FOR EACH ROW EXECUTE FUNCTION public.club_membership_revocation();
+
+DROP TRIGGER IF EXISTS club_members_revoke_delete ON public.club_members;
+CREATE TRIGGER club_members_revoke_delete
+    BEFORE DELETE ON public.club_members
+    FOR EACH ROW EXECUTE FUNCTION public.club_membership_revocation();
+
+-- 3b. A club that lapses or is suspended revokes every seat it granted.
+--     Re-activating does NOT silently re-grant: that is a deliberate act, so
+--     the owner calls club_add_members() again.
+CREATE OR REPLACE FUNCTION public.club_status_revocation()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+BEGIN
+    IF NEW.status <> 'active' AND OLD.status = 'active' THEN
+        PERFORM public.revoke_club_seats(NEW.id, NULL);
+    END IF;
+    RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS clubs_status_revoke ON public.clubs;
+CREATE TRIGGER clubs_status_revoke
+    AFTER UPDATE OF status ON public.clubs
+    FOR EACH ROW EXECUTE FUNCTION public.club_status_revocation();
+
+-- ---------------------------------------------------------------------------
+-- 4. Adding members in one action
+--
+-- Takes a list of emails. People who already have an account are granted
+-- immediately; people who do not get an 'invited' row that claim_club_invites()
+-- converts when they sign up. Returns a count of each so the caller can report
+-- honestly rather than claiming ten seats when six landed.
+-- ---------------------------------------------------------------------------
+
+CREATE OR REPLACE FUNCTION public.club_add_members(p_club_id uuid, p_emails text[])
+RETURNS TABLE (granted integer, invited integer)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+    v_email   text;
+    v_uid     uuid;
+    v_coach   uuid;
+    v_granted integer := 0;
+    v_invited integer := 0;
+BEGIN
+    IF NOT EXISTS (SELECT 1 FROM public.clubs WHERE id = p_club_id AND status = 'active') THEN
+        RAISE EXCEPTION 'club % is not active', p_club_id USING ERRCODE = 'check_violation';
+    END IF;
+
+    FOREACH v_email IN ARRAY p_emails LOOP
+        SELECT id INTO v_uid FROM auth.users WHERE lower(email) = lower(v_email);
+
+        IF v_uid IS NULL THEN
+            INSERT INTO public.club_members (club_id, invited_email, role, status)
+            VALUES (p_club_id, lower(v_email), 'member', 'invited')
+            ON CONFLICT DO NOTHING;
+            v_invited := v_invited + 1;
+        ELSE
+            INSERT INTO public.club_members (club_id, user_id, invited_email, role, status, joined_at)
+            VALUES (p_club_id, v_uid, lower(v_email), 'member', 'active', now())
+            ON CONFLICT (club_id, user_id) WHERE user_id IS NOT NULL
+            DO UPDATE SET status = 'active', removed_at = NULL, joined_at = COALESCE(public.club_members.joined_at, now());
+
+            FOR v_coach IN SELECT coach_id FROM public.club_coaches WHERE club_id = p_club_id LOOP
+                PERFORM public.grant_club_seat(p_club_id, v_uid, v_coach);
+            END LOOP;
+            v_granted := v_granted + 1;
+        END IF;
+    END LOOP;
+
+    RETURN QUERY SELECT v_granted, v_invited;
+END;
+$$;
+
+-- When an invited person signs up, link the invite and grant their seats.
+CREATE OR REPLACE FUNCTION public.claim_club_invites()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+    r     record;
+    v_coach uuid;
+BEGIN
+    FOR r IN
+        SELECT m.id, m.club_id
+        FROM public.club_members m
+        JOIN public.clubs c ON c.id = m.club_id
+        WHERE m.user_id IS NULL
+          AND lower(m.invited_email) = lower(NEW.email)
+          AND m.status = 'invited'
+          AND c.status = 'active'
+    LOOP
+        UPDATE public.club_members
+           SET user_id = NEW.id, status = 'active', joined_at = now()
+         WHERE id = r.id;
+
+        FOR v_coach IN SELECT coach_id FROM public.club_coaches WHERE club_id = r.club_id LOOP
+            PERFORM public.grant_club_seat(r.club_id, NEW.id, v_coach);
+        END LOOP;
+    END LOOP;
+    RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS claim_club_invites_on_signup ON auth.users;
+CREATE TRIGGER claim_club_invites_on_signup
+    AFTER INSERT ON auth.users
+    FOR EACH ROW EXECUTE FUNCTION public.claim_club_invites();
+
+-- Owner-facing roster. Returns membership only -- no conversation content, no
+-- goal text. #32 builds engagement aggregates on top of this.
+CREATE OR REPLACE FUNCTION public.club_roster(p_club_id uuid)
+RETURNS TABLE (
+    member_id     uuid,
+    user_id       uuid,
+    display_name  text,
+    invited_email text,
+    role          text,
+    status        text,
+    joined_at     timestamptz
+)
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+    SELECT m.id, m.user_id, up.display_name, m.invited_email, m.role, m.status, m.joined_at
+    FROM public.club_members m
+    LEFT JOIN public.user_profiles up ON up.user_id = m.user_id
+    WHERE m.club_id = p_club_id
+      AND public.is_club_owner(p_club_id)
+    ORDER BY m.status, m.joined_at NULLS LAST;
+$$;
+
+-- Commercial columns, owner only. authenticated has no SELECT on these columns
+-- at the table level, so this function is the only way to read them.
+CREATE OR REPLACE FUNCTION public.club_billing(p_club_id uuid)
+RETURNS TABLE (seats integer, seats_used bigint, plan text, billing_email text, status text)
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+    SELECT c.seats,
+           (SELECT count(*) FROM public.club_members m
+             WHERE m.club_id = c.id AND m.status = 'active'),
+           c.plan, c.billing_email, c.status
+    FROM public.clubs c
+    WHERE c.id = p_club_id
+      AND public.is_club_owner(p_club_id);
+$$;
+
+REVOKE ALL ON FUNCTION public.club_add_members(uuid, text[]) FROM PUBLIC, anon, authenticated;
+REVOKE ALL ON FUNCTION public.claim_club_invites()           FROM PUBLIC, anon, authenticated;
+REVOKE ALL ON FUNCTION public.club_roster(uuid)              FROM PUBLIC, anon;
+REVOKE ALL ON FUNCTION public.club_billing(uuid)             FROM PUBLIC, anon;
+REVOKE ALL ON FUNCTION public.club_membership_revocation()   FROM PUBLIC, anon, authenticated;
+REVOKE ALL ON FUNCTION public.club_status_revocation()       FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.club_add_members(uuid, text[]) TO service_role;
+GRANT EXECUTE ON FUNCTION public.club_roster(uuid)              TO authenticated, service_role;
+GRANT EXECUTE ON FUNCTION public.club_billing(uuid)             TO authenticated, service_role;
+
+-- ---------------------------------------------------------------------------
+-- 5. RLS
+--
+-- The rule that matters: a member may confirm their own membership and see the
+-- club's name, but must not be able to enumerate who else is in it. Squad
+-- membership is not public information -- who trains where is exactly the kind
+-- of thing a member has not consented to sharing.
+-- ---------------------------------------------------------------------------
+
+ALTER TABLE public.clubs        ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.club_members ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.club_coaches ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS "Members see their own clubs" ON public.clubs;
+CREATE POLICY "Members see their own clubs" ON public.clubs
+    FOR SELECT TO authenticated
+    USING (public.is_club_member(id));
+
+DROP POLICY IF EXISTS "Owners update their club" ON public.clubs;
+CREATE POLICY "Owners update their club" ON public.clubs
+    FOR UPDATE TO authenticated
+    USING (public.is_club_owner(id))
+    WITH CHECK (public.is_club_owner(id));
+
+DROP POLICY IF EXISTS "Members see only their own membership" ON public.club_members;
+CREATE POLICY "Members see only their own membership" ON public.club_members
+    FOR SELECT TO authenticated
+    USING (user_id = auth.uid() OR public.is_club_owner(club_id));
+
+DROP POLICY IF EXISTS "Members see coaches of their club" ON public.club_coaches;
+CREATE POLICY "Members see coaches of their club" ON public.club_coaches
+    FOR SELECT TO authenticated
+    USING (public.is_club_member(club_id));
+
+-- ---------------------------------------------------------------------------
+-- 6. Grants
+--
+-- Column-scoped on clubs: the commercial columns are simply not granted, so no
+-- policy mistake can leak them. club_billing() is the owner's read path.
+-- ---------------------------------------------------------------------------
+
+REVOKE ALL ON public.clubs        FROM anon, authenticated;
+REVOKE ALL ON public.club_members FROM anon, authenticated;
+REVOKE ALL ON public.club_coaches FROM anon, authenticated;
+
+GRANT SELECT (id, slug, name, status, creator_id, created_at) ON public.clubs TO authenticated;
+GRANT UPDATE (name, slug)                                     ON public.clubs TO authenticated;
+GRANT SELECT ON public.club_members TO authenticated;
+GRANT SELECT ON public.club_coaches TO authenticated;
+
+GRANT ALL ON public.clubs        TO service_role;
+GRANT ALL ON public.club_members TO service_role;
+GRANT ALL ON public.club_coaches TO service_role;


### PR DESCRIPTION
Closes #31.

> **Stacked on #41.** Base branch is `security/grant-rls-sweep`, not `main` — #31 asks to follow the grant discipline from #25, and both touch the probe suite. Merge #41 first and this retargets to `main` cleanly.

## The schema choice, and why

**A new `clubs` table, not a flag on `creator_profiles`.**

`creator_profiles` models a *seller*: `revenue_share_bps`, `payout_provider`, `payout_account_id`, all guarded by `protect_creator_platform_fields()`. A club is a *buyer*. Overloading the row leaves those three columns meaning nothing-or-something depending on a flag, and every existing creator query grows a "but is it a club" branch.

A club does own coaches — so it points at a `creator_profiles` row via `creator_id` rather than becoming one.

Three tables: `clubs`, `club_members` (with `role` ∈ owner/coach/member), `club_coaches` (explicit, so a club can pilot with one coach without exposing the creator's whole catalogue).

## Entitlement gets no second mechanism

Seats are `coach_subscriptions` rows with `source='creator_comp'`. `has_coach_access()` remains the single gate every read path already calls — nothing routes around it.

The one addition is `coach_subscriptions.club_id`, so revocation can target exactly the club-granted rows and nothing else.

## Revocation closes every path

The issue says "make sure there is no path where a removed member keeps talking to the coach." Three paths, asserted separately:

- flipping a member to `status='removed'` → seats revoked
- **`DELETE`ing the membership row outright** → seats revoked (a `BEFORE DELETE` trigger; easy to omit, and omitting it leaves a removed member fully entitled)
- the club going `lapsed`/`suspended` → every seat revoked

Re-activating a club deliberately does *not* silently re-grant.

## The awkward case, handled explicitly

A member may already be paying for the same coach out of their own pocket. A club seat must never overwrite that — revoking the seat later would cancel a subscription the member bought. The upsert only takes over `free_tier` / `creator_comp` / `promo` rows and leaves `apple_iap` / `google_play` / `stripe` alone. Asserted both ways: the paid row survives, and it is not marked club-granted.

## Privacy

A member may confirm their own membership and see the club's name. A member may **not** enumerate the squad — who trains where is not ours to publish, and it is the same instinct #32 is built around.

The commercial columns (`seats`, `plan`, `billing_email`, `external_billing_ref`) are **not granted to `authenticated` at all**, so no policy mistake can leak them. An owner reads them through `club_billing()`, which embeds its own ownership check.

Seat granting is backend-only. If `grant_club_seat` were reachable by `authenticated`, any signed-in member could mint themselves a comped entitlement to any coach — the entitlement system's own bypass. Asserted `42501` for both anon and a signed-in member.

`is_club_owner()` / `is_club_member()` are `SECURITY DEFINER` for a structural reason, not convenience: the RLS policy on `club_members` needs to ask "is the caller an owner of this club", which is itself a question about `club_members`. Through a policy-bound query that recurses.

## Verification

New `mobile/e2e/club-probe.mjs`, **46/0**, creating and tearing down its own fixtures (the other suites assert on the exact seeded roster). Covers the acceptance criteria directly: club created → coach attached → ten members added in one `club_add_members()` call (6 existing accounts granted, 4 invited), invite claimed on signup, removal revokes immediately *proven through `has_coach_access()`*, cross-club isolation, and the negatives.

Other suites unchanged: rls 77/0, flow 46/0, sms 55/0, account-deletion 64/0, viz-realtime 33/0. Migration is idempotent and the full chain cold-applies against the shim. `tsc --noEmit` and `terraform validate` clean.

The #25 drift detector picks up the six new `SECURITY DEFINER` functions automatically and still reports empty — which is the point of it.

## Note

`viz-realtime-probe.mjs` remains flaky (29/4 then 33/0 twice, no changes between). Websocket subscription race, not related to this work. I'm fixing it under #40.

🤖 Generated with [Claude Code](https://claude.com/claude-code)