### PR TITLE
[club] Club dashboard: who is engaging, who has gone quiet (closes #32)

### DIFF
--- a/docs/grant-matrix.md
+++ b/docs/grant-matrix.md
@@ -93,7 +93,23 @@ Bodies filter on `auth.uid()`. Granted to `authenticated`, never `anon`.
 `release_push_device(text)`, `creator_slug_available(text)`, `owns_coach(uuid)`,
 `unread_message_count(uuid)`, `has_coach_access(uuid,uuid)`,
 `get_member_context(uuid,uuid)`, `is_club_owner(uuid)`, `is_club_member(uuid)`,
-`club_roster(uuid)`, `club_billing(uuid)`
+`club_roster(uuid)`, `club_billing(uuid)`, `club_member_activity(uuid)`,
+`club_engagement_summary(uuid)`, `club_engagement_timeseries(uuid,int)`,
+`club_min_cohort()`
+
+The four club-engagement functions carry a constraint the grant alone cannot
+express: **none of them may return `conversation_messages.content`.** A club
+owner must not be able to read what their members told a coach — members
+disclose injuries they are hiding, why they stopped coming, and (see #30)
+mental-health crises. An AI summary of a named member's thread is still
+disclosure.
+
+`content` therefore appears in no `RETURNS TABLE` in
+`20260812140000_club_engagement.sql`, and `club-probe.mjs` plants recognisable
+strings in a member's messages and scans every field of every owner-reachable
+payload for them. `coach_nudges.body` is excluded on the same grounds: it is
+coach-authored, so it looks safe, but nudges are generated from the member's
+goals and can quote them back.
 
 `is_club_owner` / `is_club_member` are `SECURITY DEFINER` for a structural
 reason, not convenience: the RLS policies on `club_members` need to ask "is the

--- a/mobile/e2e/club-probe.mjs
+++ b/mobile/e2e/club-probe.mjs
@@ -253,6 +253,99 @@ try {
   check('owner of club A cannot even see club B', (crossClub?.length ?? 0) === 0,
         JSON.stringify(crossClub));
 
+  // --- engagement dashboard (issue #32) -------------------------------------
+  // The privacy constraint is the point of this section. A club owner must see
+  // whether the thing is working without seeing what anyone said.
+  section('Engagement dashboard — activity signals, never content');
+
+  const activeEmail = memberEmails[3];   // messages today
+  const dormantEmail = memberEmails[4];  // last spoke 20 days ago
+  const neverEmail = memberEmails[5];    // has never messaged
+
+  const convFor = {};
+  for (const e of [activeEmail, dormantEmail]) {
+    const uid = uidByEmail.get(e);
+    const { data: conv, error: convErr } = await admin.from('conversations')
+      .insert({ user_id: uid, coach_id: coach.id, channel: 'app' })
+      .select('id').single();
+    if (convErr) throw new Error(`conversation for ${e}: ${convErr.message}`);
+    convFor[e] = conv.id;
+  }
+
+  const daysAgo = (n) => new Date(Date.now() - n * 86400000).toISOString();
+  const { error: msgErr } = await admin.from('conversation_messages').insert([
+    { conversation_id: convFor[activeEmail], role: 'user',
+      content: 'PRIVATE-DISCLOSURE-ACTIVE hiding a hamstring strain', created_at: daysAgo(1) },
+    { conversation_id: convFor[activeEmail], role: 'assistant',
+      content: 'coach reply', created_at: daysAgo(1) },
+    { conversation_id: convFor[dormantEmail], role: 'user',
+      content: 'PRIVATE-DISCLOSURE-DORMANT why I stopped coming', created_at: daysAgo(20) },
+  ]);
+  check('seeded a fixture: one active, one dormant, one never', !msgErr, msgErr?.message);
+
+  const { data: activity, error: actErr } = await ownerClient.rpc('club_member_activity', { p_club_id: club.id });
+  check('owner reads per-member activity', !actErr && (activity?.length ?? 0) > 0, actErr?.message);
+
+  const byUser = Object.fromEntries((activity ?? []).map(a => [a.user_id, a]));
+  check('  → the active member reads as active',
+        byUser[uidByEmail.get(activeEmail)]?.state === 'active',
+        JSON.stringify(byUser[uidByEmail.get(activeEmail)]?.state));
+  check('  → the 20-day-quiet member reads as dormant',
+        byUser[uidByEmail.get(dormantEmail)]?.state === 'dormant',
+        JSON.stringify(byUser[uidByEmail.get(dormantEmail)]?.state));
+  check('  → the silent member reads as never',
+        byUser[uidByEmail.get(neverEmail)]?.state === 'never',
+        JSON.stringify(byUser[uidByEmail.get(neverEmail)]?.state));
+  check('  → dormant member carries a days-since-active figure',
+        byUser[uidByEmail.get(dormantEmail)]?.days_since_active >= 19,
+        JSON.stringify(byUser[uidByEmail.get(dormantEmail)]?.days_since_active));
+
+  const { data: summary, error: sumErr } = await ownerClient.rpc('club_engagement_summary', { p_club_id: club.id });
+  const s = Array.isArray(summary) ? summary[0] : summary;
+  check('owner reads the squad summary', !sumErr && !!s, sumErr?.message);
+  check('  → counts add up to the membership',
+        Number(s?.active_this_week) + Number(s?.slowing) + Number(s?.dormant_14d) + Number(s?.never_messaged)
+          === Number(s?.members_total),
+        JSON.stringify(s));
+  check('  → messages_this_week counts only member turns, not coach replies',
+        Number(s?.messages_this_week) === 1, JSON.stringify(s?.messages_this_week));
+
+  const { data: series, error: seriesErr } = await ownerClient.rpc('club_engagement_timeseries',
+    { p_club_id: club.id, p_days: 30 });
+  check('owner reads engagement over time', !seriesErr && (series?.length ?? 0) >= 30, seriesErr?.message);
+
+  // THE assertion this whole issue exists for. Not "review checked it" —
+  // every value of every row of every reachable endpoint, scanned for the
+  // disclosures we planted above.
+  const planted = ['PRIVATE-DISCLOSURE-ACTIVE', 'PRIVATE-DISCLOSURE-DORMANT',
+                   'hamstring', 'why I stopped coming'];
+  const payloads = [activity, summary, series, ownerRoster];
+  const serialised = JSON.stringify(payloads);
+  check('NO club-owner endpoint returns message content',
+        !planted.some(p => serialised.includes(p)),
+        planted.filter(p => serialised.includes(p)).join(', '));
+  check('  → and no returned column is even named `content`',
+        !payloads.some(rows => (rows ?? []).some(r => Object.keys(r ?? {}).some(
+          k => k === 'content' || k === 'body'))),
+        JSON.stringify(Object.keys(activity?.[0] ?? {})));
+
+  // A member of the club is not an owner of it.
+  const { data: memberActivity } = await memberClient.rpc('club_member_activity', { p_club_id: club.id });
+  check('a member may NOT read the squad activity', (memberActivity?.length ?? 0) === 0,
+        JSON.stringify(memberActivity?.length));
+  const { data: memberSummary } = await memberClient.rpc('club_engagement_summary', { p_club_id: club.id });
+  check('a member may NOT read the squad summary', (memberSummary?.length ?? 0) === 0,
+        JSON.stringify(memberSummary));
+
+  // Cross-club.
+  const { data: crossActivity } = await ownerClient.rpc('club_member_activity', { p_club_id: club2.id });
+  check('owner of club A reads nothing about club B', (crossActivity?.length ?? 0) === 0,
+        JSON.stringify(crossActivity?.length));
+
+  const { error: anonActivityErr } = await anon.rpc('club_member_activity', { p_club_id: club.id });
+  check('anon may NOT call club_member_activity()', anonActivityErr?.code === '42501',
+        anonActivityErr ? `got ${anonActivityErr.code}` : 'call succeeded!');
+
   // --- club lapses ----------------------------------------------------------
   section('A club that lapses revokes every seat');
   const { data: stillActive } = await admin.from('coach_subscriptions')

--- a/supabase/migrations/20260812140000_club_engagement.sql
+++ b/supabase/migrations/20260812140000_club_engagement.sql
@@ -1,0 +1,214 @@
+-- ---------------------------------------------------------------------------
+-- Club engagement dashboard (issue #32)
+--
+-- The club owner needs to know whether the thing is working. The hard part is
+-- what they must NOT be able to see.
+--
+-- A member discloses things to a coach that they would never say to the person
+-- who runs their club: injuries they are hiding, why they stopped coming,
+-- personal circumstances. #30 exists because members disclose mental-health
+-- crises in these threads. Surfacing any of that to an owner would be a serious
+-- breach and would destroy the candour the coaching depends on.
+--
+-- So every function here is built on activity signals and counts. None of them
+-- reads `conversation_messages.content`, and none of them can be made to --
+-- `content` does not appear in a single RETURNS TABLE in this file, and
+-- club-probe asserts that at runtime rather than trusting review.
+--
+-- Also excluded, less obviously: `coach_nudges.body`. It is coach-authored
+-- rather than member-authored, so it looks safe, but nudges are generated from
+-- the member's own goals and can quote them back. It stays out.
+--
+-- What IS allowed, per the issue: message counts, last-active dates, streaks,
+-- active/dormant counts, engagement over time, nudge response rate.
+--
+-- Themed aggregates ("6 members asked about knee pain") are deliberately NOT
+-- in v1. With a ten-person squad the minimum cohort size that would make them
+-- non-attributable is most of the squad, at which point they say nothing. The
+-- issue says to leave it out if in doubt. It is out. MIN_COHORT below records
+-- the threshold for whoever revisits this.
+-- ---------------------------------------------------------------------------
+
+-- The smallest group that may be described in aggregate without the
+-- description being traceable to an individual. Referenced by any future themed
+-- aggregate; nothing in v1 renders below it.
+CREATE OR REPLACE FUNCTION public.club_min_cohort()
+RETURNS integer LANGUAGE sql IMMUTABLE AS $$ SELECT 5 $$;
+
+COMMENT ON FUNCTION public.club_min_cohort() IS
+    'Minimum cohort size before an aggregate may be shown. With a 10-person squad, "2 members asked about X" is close to identifying.';
+
+-- ---------------------------------------------------------------------------
+-- Per-member activity. This is the actionable one: the dormant list is what a
+-- head coach actually does something with.
+--
+-- Returns when someone last spoke and how much, never what they said.
+-- ---------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public.club_member_activity(p_club_id uuid)
+RETURNS TABLE (
+    member_id        uuid,
+    user_id          uuid,
+    display_name     text,
+    role             text,
+    joined_at        timestamptz,
+    last_active_at   timestamptz,
+    days_since_active integer,
+    messages_30d     bigint,
+    messages_total   bigint,
+    state            text
+)
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+    WITH member AS (
+        SELECT m.id, m.user_id, m.role, m.joined_at, up.display_name
+        FROM public.club_members m
+        LEFT JOIN public.user_profiles up ON up.user_id = m.user_id
+        WHERE m.club_id = p_club_id
+          AND m.status = 'active'
+          AND m.user_id IS NOT NULL
+    ),
+    -- Only the member's own turns count as activity. A coach nudge landing in
+    -- the thread is not the member engaging.
+    activity AS (
+        SELECT c.user_id,
+               max(cm.created_at)                                             AS last_active_at,
+               count(*) FILTER (WHERE cm.created_at > now() - interval '30 days') AS messages_30d,
+               count(*)                                                       AS messages_total
+        FROM public.conversations c
+        JOIN public.conversation_messages cm ON cm.conversation_id = c.id
+        JOIN public.club_coaches cc ON cc.coach_id = c.coach_id AND cc.club_id = p_club_id
+        WHERE cm.role = 'user'
+        GROUP BY c.user_id
+    )
+    SELECT
+        m.id,
+        m.user_id,
+        m.display_name,
+        m.role,
+        m.joined_at,
+        a.last_active_at,
+        CASE WHEN a.last_active_at IS NULL THEN NULL
+             ELSE EXTRACT(DAY FROM now() - a.last_active_at)::int END,
+        COALESCE(a.messages_30d, 0),
+        COALESCE(a.messages_total, 0),
+        CASE
+            WHEN a.last_active_at IS NULL                              THEN 'never'
+            WHEN a.last_active_at > now() - interval '7 days'          THEN 'active'
+            WHEN a.last_active_at > now() - interval '14 days'         THEN 'slowing'
+            ELSE 'dormant'
+        END
+    FROM member m
+    LEFT JOIN activity a ON a.user_id = m.user_id
+    WHERE public.is_club_owner(p_club_id)
+    ORDER BY a.last_active_at NULLS FIRST;
+$$;
+
+-- ---------------------------------------------------------------------------
+-- Squad-level summary.
+-- ---------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public.club_engagement_summary(p_club_id uuid)
+RETURNS TABLE (
+    members_total       bigint,
+    active_this_week    bigint,
+    slowing             bigint,
+    dormant_14d         bigint,
+    never_messaged      bigint,
+    messages_this_week  bigint,
+    nudges_sent_30d     bigint,
+    nudges_replied_30d  bigint,
+    nudge_response_rate numeric
+)
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+    WITH a AS (
+        SELECT * FROM public.club_member_activity(p_club_id)
+    ),
+    nudge AS (
+        SELECT
+            count(*) AS sent,
+            count(*) FILTER (WHERE EXISTS (
+                SELECT 1 FROM public.conversation_messages cm
+                WHERE cm.conversation_id = n.conversation_id
+                  AND cm.role = 'user'
+                  AND cm.created_at BETWEEN n.created_at AND n.created_at + interval '48 hours'
+            )) AS replied
+        FROM public.coach_nudges n
+        JOIN public.club_members m ON m.user_id = n.user_id AND m.club_id = p_club_id AND m.status = 'active'
+        JOIN public.club_coaches cc ON cc.coach_id = n.coach_id AND cc.club_id = p_club_id
+        WHERE n.created_at > now() - interval '30 days'
+          AND n.status = 'sent'
+    )
+    SELECT
+        (SELECT count(*) FROM a),
+        (SELECT count(*) FROM a WHERE state = 'active'),
+        (SELECT count(*) FROM a WHERE state = 'slowing'),
+        (SELECT count(*) FROM a WHERE state = 'dormant'),
+        (SELECT count(*) FROM a WHERE state = 'never'),
+        (SELECT COALESCE(sum(cnt), 0) FROM (
+            SELECT count(*) AS cnt
+            FROM public.conversations c
+            JOIN public.conversation_messages cm ON cm.conversation_id = c.id
+            JOIN public.club_coaches cc ON cc.coach_id = c.coach_id AND cc.club_id = p_club_id
+            JOIN public.club_members m ON m.user_id = c.user_id AND m.club_id = p_club_id AND m.status = 'active'
+            WHERE cm.role = 'user' AND cm.created_at > now() - interval '7 days'
+        ) s),
+        (SELECT sent FROM nudge),
+        (SELECT replied FROM nudge),
+        (SELECT CASE WHEN sent = 0 THEN NULL
+                     ELSE round((replied::numeric / sent) * 100, 1) END FROM nudge)
+    WHERE public.is_club_owner(p_club_id);
+$$;
+
+-- ---------------------------------------------------------------------------
+-- Engagement over time. Counts per day, nothing else.
+-- ---------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public.club_engagement_timeseries(p_club_id uuid, p_days integer DEFAULT 30)
+RETURNS TABLE (day date, active_members bigint, messages bigint)
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+    SELECT d.day::date,
+           count(DISTINCT c.user_id),
+           count(cm.id)
+    FROM generate_series(
+             (now() - make_interval(days => GREATEST(1, LEAST(p_days, 365))))::date,
+             now()::date,
+             interval '1 day') AS d(day)
+    LEFT JOIN public.conversations c
+           ON EXISTS (SELECT 1 FROM public.club_coaches cc
+                       WHERE cc.coach_id = c.coach_id AND cc.club_id = p_club_id)
+          AND EXISTS (SELECT 1 FROM public.club_members m
+                       WHERE m.user_id = c.user_id AND m.club_id = p_club_id AND m.status = 'active')
+    LEFT JOIN public.conversation_messages cm
+           ON cm.conversation_id = c.id
+          AND cm.role = 'user'
+          AND cm.created_at::date = d.day::date
+    WHERE public.is_club_owner(p_club_id)
+    GROUP BY d.day
+    ORDER BY d.day;
+$$;
+
+-- ---------------------------------------------------------------------------
+-- Grants. Per docs/grant-matrix.md: revoke the PUBLIC default first, then grant
+-- deliberately. Each function embeds is_club_owner() in its own WHERE, so a
+-- non-owner gets zero rows rather than an error -- an owner of club A probing
+-- club B learns nothing about whether club B exists.
+-- ---------------------------------------------------------------------------
+
+REVOKE ALL ON FUNCTION public.club_member_activity(uuid)              FROM PUBLIC, anon;
+REVOKE ALL ON FUNCTION public.club_engagement_summary(uuid)           FROM PUBLIC, anon;
+REVOKE ALL ON FUNCTION public.club_engagement_timeseries(uuid, integer) FROM PUBLIC, anon;
+REVOKE ALL ON FUNCTION public.club_min_cohort()                       FROM PUBLIC, anon;
+
+GRANT EXECUTE ON FUNCTION public.club_member_activity(uuid)              TO authenticated, service_role;
+GRANT EXECUTE ON FUNCTION public.club_engagement_summary(uuid)           TO authenticated, service_role;
+GRANT EXECUTE ON FUNCTION public.club_engagement_timeseries(uuid, integer) TO authenticated, service_role;
+GRANT EXECUTE ON FUNCTION public.club_min_cohort()                       TO authenticated, service_role;

--- a/webapp/src/App.jsx
+++ b/webapp/src/App.jsx
@@ -29,6 +29,7 @@ import CoachEdit from './components/MyCoaches/CoachEdit';
 import CoachAvatarEdit from './components/MyCoaches/CoachAvatarEdit';
 import CreatorProfilePage from './components/Creator/CreatorProfilePage';
 import AdminDashboard from './components/AdminDashboard';
+import ClubDashboard from './components/Club/ClubDashboard';
 import { AdminProtectedRoute } from './components/AdminProtectedRoute';
 
 const stripePromise = loadStripe(STRIPE_PUBLIC_KEY);
@@ -128,6 +129,7 @@ export function App() {
         <Route path="/my-coaches/:coachId/content" element={<CoachContentManager />} />
         <Route path="/my-coaches/:coachId/edit" element={<CoachEdit />} />
         <Route path="/my-coaches/:coachId/avatar" element={<CoachAvatarEdit />} />
+        <Route path="/club" element={<ClubDashboard />} />
         <Route path="/admin" element={<AdminProtectedRoute session={session}><AdminDashboard /></AdminProtectedRoute>} />
       </Route>
 

--- a/webapp/src/components/Club/ClubDashboard.jsx
+++ b/webapp/src/components/Club/ClubDashboard.jsx
@@ -1,0 +1,271 @@
+import React, { useEffect, useMemo, useState } from 'react';
+import { toast } from 'react-hot-toast';
+import { supabase } from '../../main';
+
+/**
+ * The club owner's view of whether the thing is working.
+ *
+ * Everything here is an activity signal. There is no code path in this
+ * component that can render a message body, because the functions it calls do
+ * not return one — see supabase/migrations/20260812140000_club_engagement.sql
+ * and the assertion in mobile/e2e/club-probe.mjs.
+ *
+ * The dormant list leads, because it is the only part an owner can act on.
+ */
+
+const STATE_STYLE = {
+  active:  { label: 'Active',        cls: 'bg-green-100 text-green-800' },
+  slowing: { label: 'Slowing down',  cls: 'bg-yellow-100 text-yellow-800' },
+  dormant: { label: 'Gone quiet',    cls: 'bg-red-100 text-red-800' },
+  never:   { label: 'Never started', cls: 'bg-gray-200 text-gray-700' },
+};
+
+function Stat({ label, value, hint, tone = 'default' }) {
+  const toneCls = tone === 'warn' ? 'text-red-600' : 'text-gray-900';
+  return (
+    <div className="rounded-lg border border-gray-200 bg-white p-4">
+      <div className="text-xs font-medium uppercase tracking-wider text-gray-500">{label}</div>
+      <div className={`mt-1 text-3xl font-semibold ${toneCls}`}>{value ?? '—'}</div>
+      {hint && <div className="mt-1 text-xs text-gray-500">{hint}</div>}
+    </div>
+  );
+}
+
+/**
+ * The promise we make to members, stated where the owner can see it. Members
+ * are told the same thing, so this has to stay true to what the SQL does.
+ */
+function PrivacyNotice() {
+  return (
+    <div className="rounded-lg border border-blue-200 bg-blue-50 p-4 text-sm text-blue-900">
+      <div className="font-semibold">What you can and cannot see</div>
+      <p className="mt-1">
+        You can see <strong>whether</strong> your members are engaging — when they last
+        spoke to their coach, how often, and who has gone quiet.
+      </p>
+      <p className="mt-1">
+        You cannot see <strong>what</strong> they said. Conversations between a member and
+        their coach are private, including from you. No message, quote, extract or summary
+        of a member&apos;s conversation is available on this page or anywhere else in your
+        account. Members are told this too — it is what makes them honest with their coach.
+      </p>
+    </div>
+  );
+}
+
+function Sparkline({ series }) {
+  const points = useMemo(() => {
+    if (!series?.length) return '';
+    const max = Math.max(1, ...series.map((d) => Number(d.messages)));
+    return series
+      .map((d, i) => {
+        const x = (i / Math.max(1, series.length - 1)) * 100;
+        const y = 30 - (Number(d.messages) / max) * 28;
+        return `${x.toFixed(2)},${y.toFixed(2)}`;
+      })
+      .join(' ');
+  }, [series]);
+
+  if (!series?.length) return null;
+  return (
+    <svg viewBox="0 0 100 30" preserveAspectRatio="none" className="h-16 w-full" role="img"
+         aria-label="Member messages per day over the last 30 days">
+      <polyline points={points} fill="none" stroke="currentColor" strokeWidth="1"
+                className="text-indigo-500" vectorEffect="non-scaling-stroke" />
+    </svg>
+  );
+}
+
+export default function ClubDashboard() {
+  const [clubs, setClubs] = useState([]);
+  const [clubId, setClubId] = useState(null);
+  const [summary, setSummary] = useState(null);
+  const [activity, setActivity] = useState([]);
+  const [series, setSeries] = useState([]);
+  const [loading, setLoading] = useState(true);
+
+  // Clubs where this account is an owner or head coach. RLS lets a member read
+  // their own club_members row, so this needs no privileged endpoint.
+  useEffect(() => {
+    let mounted = true;
+    (async () => {
+      const { data: session } = await supabase.auth.getSession();
+      const uid = session?.session?.user?.id;
+      if (!uid) { setLoading(false); return; }
+
+      const { data, error } = await supabase
+        .from('club_members')
+        .select('club_id, role, clubs ( id, name, slug )')
+        .eq('user_id', uid)
+        .in('role', ['owner', 'coach'])
+        .eq('status', 'active');
+
+      if (!mounted) return;
+      if (error) { toast.error(`Could not load your clubs: ${error.message}`); setLoading(false); return; }
+
+      const list = (data ?? []).map((r) => r.clubs).filter(Boolean);
+      setClubs(list);
+      setClubId((prev) => prev ?? list[0]?.id ?? null);
+      setLoading(false);
+    })();
+    return () => { mounted = false; };
+  }, []);
+
+  useEffect(() => {
+    if (!clubId) return;
+    let mounted = true;
+    setLoading(true);
+    (async () => {
+      const [sum, act, ts] = await Promise.all([
+        supabase.rpc('club_engagement_summary', { p_club_id: clubId }),
+        supabase.rpc('club_member_activity', { p_club_id: clubId }),
+        supabase.rpc('club_engagement_timeseries', { p_club_id: clubId, p_days: 30 }),
+      ]);
+      if (!mounted) return;
+
+      // A permission failure and an empty club are not the same thing, and
+      // must not read the same way. See docs/grant-matrix.md.
+      const err = sum.error || act.error || ts.error;
+      if (err) toast.error(`Could not load engagement: ${err.message}`);
+
+      setSummary(Array.isArray(sum.data) ? sum.data[0] : sum.data);
+      setActivity(act.data ?? []);
+      setSeries(ts.data ?? []);
+      setLoading(false);
+    })();
+    return () => { mounted = false; };
+  }, [clubId]);
+
+  const needsAttention = activity.filter((m) => m.state === 'dormant' || m.state === 'never');
+
+  if (loading && !summary) {
+    return <div className="p-6 text-gray-500">Loading…</div>;
+  }
+
+  if (!clubs.length) {
+    return (
+      <div className="mx-auto max-w-2xl p-6">
+        <h1 className="text-2xl font-semibold text-gray-900">Club dashboard</h1>
+        <p className="mt-2 text-gray-600">
+          This account does not run a club. If you expected to see one here, ask whoever set
+          the club up to add you as an owner.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="mx-auto max-w-5xl space-y-6 p-6">
+      <header className="flex flex-wrap items-center justify-between gap-3">
+        <div>
+          <h1 className="text-2xl font-semibold text-gray-900">Club dashboard</h1>
+          <p className="text-sm text-gray-600">Who is engaging, and who has gone quiet.</p>
+        </div>
+        {clubs.length > 1 && (
+          <select
+            value={clubId ?? ''}
+            onChange={(e) => setClubId(e.target.value)}
+            className="rounded-md border border-gray-300 px-3 py-2 text-sm"
+          >
+            {clubs.map((c) => <option key={c.id} value={c.id}>{c.name}</option>)}
+          </select>
+        )}
+      </header>
+
+      <PrivacyNotice />
+
+      {/* The actionable list first. A count of dormant members is a number; a
+          list of who they are is something a coach can do something about. */}
+      <section>
+        <h2 className="mb-2 text-lg font-semibold text-gray-900">
+          Needs a nudge{needsAttention.length ? ` (${needsAttention.length})` : ''}
+        </h2>
+        {needsAttention.length === 0 ? (
+          <div className="rounded-lg border border-green-200 bg-green-50 p-4 text-sm text-green-900">
+            Everyone has spoken to their coach in the last two weeks.
+          </div>
+        ) : (
+          <ul className="divide-y divide-gray-200 rounded-lg border border-gray-200 bg-white">
+            {needsAttention.map((m) => (
+              <li key={m.member_id} className="flex items-center justify-between px-4 py-3">
+                <div>
+                  <div className="text-sm font-medium text-gray-900">
+                    {m.display_name || 'Member'}
+                  </div>
+                  <div className="text-xs text-gray-500">
+                    {m.state === 'never'
+                      ? 'Has never messaged their coach'
+                      : `Last spoke ${m.days_since_active} days ago`}
+                  </div>
+                </div>
+                <span className={`rounded-full px-2 py-1 text-xs font-medium ${STATE_STYLE[m.state].cls}`}>
+                  {STATE_STYLE[m.state].label}
+                </span>
+              </li>
+            ))}
+          </ul>
+        )}
+      </section>
+
+      <section className="grid grid-cols-2 gap-4 md:grid-cols-4">
+        <Stat label="Members" value={summary?.members_total} />
+        <Stat label="Active this week" value={summary?.active_this_week} />
+        <Stat label="Gone quiet (14d+)" value={summary?.dormant_14d}
+              tone={Number(summary?.dormant_14d) > 0 ? 'warn' : 'default'} />
+        <Stat label="Never started" value={summary?.never_messaged}
+              tone={Number(summary?.never_messaged) > 0 ? 'warn' : 'default'} />
+      </section>
+
+      <section className="grid gap-4 md:grid-cols-2">
+        <div className="rounded-lg border border-gray-200 bg-white p-4">
+          <div className="text-xs font-medium uppercase tracking-wider text-gray-500">
+            Member messages, last 30 days
+          </div>
+          <Sparkline series={series} />
+        </div>
+        <Stat
+          label="Nudge response rate"
+          value={summary?.nudge_response_rate == null ? '—' : `${summary.nudge_response_rate}%`}
+          hint={
+            summary?.nudges_sent_30d
+              ? `${summary.nudges_replied_30d} of ${summary.nudges_sent_30d} nudges got a reply within 48 hours`
+              : 'No nudges sent in the last 30 days'
+          }
+        />
+      </section>
+
+      <section>
+        <h2 className="mb-2 text-lg font-semibold text-gray-900">Everyone</h2>
+        <div className="overflow-x-auto rounded-lg border border-gray-200 bg-white">
+          <table className="min-w-full divide-y divide-gray-200">
+            <thead className="bg-gray-50">
+              <tr>
+                {['Member', 'Status', 'Last active', 'Messages (30d)'].map((h) => (
+                  <th key={h} className="px-3 py-2 text-left text-xs font-medium uppercase tracking-wider text-gray-500">
+                    {h}
+                  </th>
+                ))}
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-gray-200 bg-white">
+              {activity.map((m) => (
+                <tr key={m.member_id}>
+                  <td className="px-3 py-2 text-sm text-gray-900">{m.display_name || 'Member'}</td>
+                  <td className="px-3 py-2 text-sm">
+                    <span className={`rounded-full px-2 py-1 text-xs font-medium ${STATE_STYLE[m.state].cls}`}>
+                      {STATE_STYLE[m.state].label}
+                    </span>
+                  </td>
+                  <td className="px-3 py-2 text-sm text-gray-700">
+                    {m.last_active_at ? `${m.days_since_active}d ago` : '—'}
+                  </td>
+                  <td className="px-3 py-2 text-sm text-gray-700">{m.messages_30d}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </section>
+    </div>
+  );
+}


### PR DESCRIPTION
Closes #32.

> **Stacked on #42** (which is stacked on #41). Base is `club/first-class-entity`. Merge in order — #41 → #42 → this — and each retargets cleanly.

## The privacy constraint, which is the hard part

A member discloses things to a coach they would never say to the person who runs their club: injuries they are hiding, why they stopped coming, personal circumstances. #30 exists because members disclose mental-health crises in these threads.

So this is built on activity signals and counts. **`content` appears in no `RETURNS TABLE` in the migration** — and the probe doesn't take that on trust. It plants recognisable strings in a member's messages:

```
'PRIVATE-DISCLOSURE-ACTIVE hiding a hamstring strain'
'PRIVATE-DISCLOSURE-DORMANT why I stopped coming'
```

…then scans every field of every owner-reachable payload for them, and separately asserts no returned column is even *named* `content` or `body`.

`coach_nudges.body` is excluded on the same grounds. It's coach-authored so it looks safe — but nudges are generated from the member's own goals and can quote them back.

**Themed aggregates are deliberately not in v1.** With a ten-person squad, the minimum cohort size that would make "6 members asked about knee pain" non-attributable is most of the squad, at which point it says nothing. The issue says leave it out if in doubt. `club_min_cohort()` records the threshold (5) for whoever revisits it.

## Metrics

Active this week / slowing / dormant 14d+ / never messaged, member messages over time, and nudge response rate — a reply within 48h of a *sent* nudge.

Only the member's **own turns** count as activity. A coach nudge landing in the thread is not the member engaging; counting it would make a silent member look active, which is exactly the failure the dashboard exists to prevent. Asserted: `messages_this_week === 1` against a fixture with one member turn and one coach reply.

## Authorisation

Every function embeds `is_club_owner()` in its own `WHERE`, so a non-owner gets **zero rows rather than an error**. That's deliberate: an owner of club A probing club B learns nothing about whether club B exists.

Grants follow `docs/grant-matrix.md` — revoked from `PUBLIC`/`anon` first, then granted. The #25 drift detector picks the four new functions up automatically and still reports empty.

## The UI

`/club`, leading with the dormant list — a count is a number, a list of names is something a head coach can act on.

The privacy constraint is stated **in the UI itself**, so members can be told truthfully what their club owner can and cannot see. That promise is part of the product, so it lives where the owner reads it, not just in a doc.

The mount query (`club_members` → embedded `clubs`) was verified to resolve under RLS with the column-scoped grants from #31 — that's the kind of thing that fails silently at runtime rather than at build.

## Verification

`club-probe.mjs` **46 → 62 checks**, all green. Dormant-list correctness is asserted against a seeded fixture: one member messaging today reads `active`, one at 20 days reads `dormant` with a days-since figure, one who never messaged reads `never`, and the four state counts sum to `members_total`.

Full suite: rls 77/0, club 62/0, flow 46/0, sms 55/0, account-deletion 64/0, viz-realtime 33/0. `tsc --noEmit` clean, `npm run build` clean, migration idempotent and cold-applies against the shim.

🤖 Generated with [Claude Code](https://claude.com/claude-code)