### PR TITLE
probes: close the gaps #40 documents — drift guard, realtime flake, mock URL

### DIFF
--- a/functions/coach-avatar-generator/index.js
+++ b/functions/coach-avatar-generator/index.js
@@ -150,60 +150,16 @@ exports.generateCoachAvatar = async (req, res) => {
   });
 };
 
-/**
- * Function to save selected avatar to coach profile
- */
-exports.saveSelectedAvatar = async (req, res) => {
-  // Set CORS headers
-  Object.keys(corsHeaders).forEach(key => {
-    res.set(key, corsHeaders[key]);
-  });
+/*
+  There is no second export here on purpose. A `saveSelectedAvatar` handler used
+  to live below this line: it took a `coachId` and an avatar URL from the request
+  body and wrote them straight onto that row in `coach_profiles`, with no token
+  check and no ownership check. Terraform never gave it an `entry_point`, so it
+  was never deployed and never reachable — the webapp's calls to
+  `/coach-avatar-generator/save-avatar` (removed in #22) hit the generator above,
+  which does not route on path, rather than that handler.
 
-  // Handle preflight requests
-  if (req.method === 'OPTIONS') {
-    res.status(204).send('');
-    return;
-  }
-
-  try {
-    const { coachId, selectedAvatarUrl, avatarStyle, originalSelfieUrl } = req.body;
-
-    if (!coachId || !selectedAvatarUrl || !avatarStyle) {
-      return res.status(400).json({ 
-        error: 'coachId, selectedAvatarUrl, and avatarStyle are required' 
-      });
-    }
-
-    console.log(`Saving selected avatar for coach ${coachId}: ${avatarStyle}`);
-
-    // Update coach profile with selected avatar
-    const { data, error } = await supabase
-      .from('coach_profiles')
-      .update({
-        avatar_url: selectedAvatarUrl,
-        avatar_style: avatarStyle,
-        original_selfie_url: originalSelfieUrl,
-        updated_at: new Date().toISOString()
-      })
-      .eq('id', coachId)
-      .select()
-      .single();
-
-    if (error) {
-      console.error('Database error:', error);
-      throw error;
-    }
-
-    res.status(200).json({
-      success: true,
-      coach: data,
-      message: 'Avatar saved successfully'
-    });
-
-  } catch (error) {
-    console.error('Save avatar error:', error);
-    res.status(500).json({ 
-      error: error.message || 'Failed to save selected avatar'
-    });
-  }
-}; 
+  It is deleted rather than left dormant because the only thing it was still
+  doing was waiting for someone to wire it up and ship an IDOR. Saving a chosen
+  avatar belongs on an authenticated path that checks the caller owns the coach.
+*/

--- a/mobile/e2e/README.md
+++ b/mobile/e2e/README.md
@@ -1,6 +1,6 @@
 # End-to-end probes
 
-Five suites that exercise the backend the way the app does — through
+Seven suites that exercise the backend the way the app does — through
 PostgREST as a real `anon`/`authenticated` user, so RLS is actually in play,
 and through the Cloud Functions over HTTP.
 
@@ -11,6 +11,7 @@ and through the Cloud Functions over HTTP.
 | `viz-realtime-probe.mjs` | Visualiser guards (`no_aspiration`, entitlement, daily limit), prompt hygiene, likeness consent and reference photos, and realtime delivery of a coach-initiated message |
 | `sms-image-probe.mjs` | The daily SMS image job across three disciplines: channel scoping, coach resolution, goal-driven prompts, likeness consent, and that no member can receive fitness before/after imagery |
 | `club-probe.mjs` | Clubs: seats granted through `coach_subscriptions` so `has_coach_access()` stays the only gate, the invite-on-signup path, revocation by removal / deletion / club lapse, and the negatives — a member cannot enumerate the squad, read what the club pays, or mint themselves a seat |
+| `creator-probe.mjs` | Creator onboarding and publishing: profile creation, `protect_creator_platform_fields()` and `enforce_coach_listing_rules()`, that publishing fails while under review, that a creator can neither approve themselves nor credit a coach to someone else, and that suspension pulls the listings |
 | `account-deletion-probe.mjs` | Account deletion: that no row in any affected table survives, that the reference photo **object** is gone from the bucket, what happens to coaches the member created and to the people subscribed to them, and that a photo we cannot delete stops the whole deletion |
 
 ## Setting up a local stack
@@ -74,7 +75,11 @@ ENV_FILE=/tmp/cabo-local/local.env node e2e/flow-probe.mjs
 ENV_FILE=/tmp/cabo-local/local.env node e2e/viz-realtime-probe.mjs
 ENV_FILE=/tmp/cabo-local/local.env node e2e/sms-image-probe.mjs
 ENV_FILE=/tmp/cabo-local/local.env node e2e/account-deletion-probe.mjs
+ENV_FILE=/tmp/cabo-local/local.env node e2e/creator-probe.mjs
 ```
+
+A green run across all seven is 378 checks. `creator-probe.mjs` needs neither
+the gateway nor the mock model — it goes through PostgREST only.
 
 `sms-image-probe.mjs` needs the mock model but not the gateway: it calls the
 daily job's modules in-process and fakes Replicate, Twilio and GCS, so it needs
@@ -95,6 +100,22 @@ on any failure.
 Ports are overridable, so a second stack can run beside the first without the
 two gateways fighting over 8790: `PORT` on both harness processes,
 `MOCK_OPENAI_URL` on the gateway, and `API_BASE` on the probes.
+
+`MOCK_OPENAI_URL` means the OpenAI *base* URL (`http://127.0.0.1:8791/v1`) to
+the gateway, because the SDK appends the route itself, but
+`sms-image-probe.mjs` calls the endpoint directly and needs
+`.../v1/chat/completions`. The probe now accepts either form; if you write your
+own harness, note that a mismatch here returns 404 and reads as twenty
+unrelated failures ("no scene was sent", "0 Replicate calls") rather than as a
+wiring mistake.
+
+Realtime replays the WAL in order, so `viz-realtime-probe.mjs` run straight
+after the write-heavy suites may see its event arrive seconds late while the
+backlog drains. Its realtime assertions wait for delivery rather than sleeping
+a fixed interval, and the no-leak assertion is pinned to a positive delivery on
+a second subscription — a bare sleep would pass just as happily against a
+realtime server that had stopped delivering anything at all. Keep that shape if
+you add realtime coverage.
 
 The visualiser's likeness endpoints need GCS credentials to store or delete a
 photo, so `/likeness/grant` cannot be exercised locally. Everything the choice

--- a/mobile/e2e/prompt-eval/crisis-probe.mjs
+++ b/mobile/e2e/prompt-eval/crisis-probe.mjs
@@ -55,14 +55,60 @@ const { buildSystemPromptV2 } = require(path.join(FN, 'coach-prompt-v2.js'));
 
 section('The deployed copies are the shared file');
 {
-  const shared = fs.readFileSync(path.join(REPO, 'functions/shared/crisis.js'), 'utf8');
-  for (const dir of ['coach-response-generator', 'coach-nudges', 'process-sms']) {
-    const copy = path.join(REPO, 'functions', dir, 'crisis.js');
-    check(
-      `functions/${dir}/crisis.js is an exact copy of functions/shared/crisis.js`,
-      fs.existsSync(copy) && fs.readFileSync(copy, 'utf8') === shared
-    );
+  /*
+    Cloud Functions are zipped per-directory, so `require('../shared/...')` does
+    not survive deploy and each function carries its own copy. The duplication is
+    deliberate; the drift is not. These modules have already drifted apart once
+    (a `coach.tagline` fix landed in `shared/` and never reached the deployed
+    copy), and nothing caught it, because a prompt change that silently does not
+    apply in production looks exactly like a prompt change that did not work.
+
+    Every shared module belongs in this table. Adding a fourth copy of something
+    without adding it here is how the next drift gets in.
+  */
+  const DUPLICATED = {
+    'crisis.js': ['coach-response-generator', 'coach-nudges', 'process-sms'],
+    'coach-domain.js': ['coach-response-generator'],
+    'coach-prompt-v2.js': ['coach-response-generator'],
+    'goal-onboarding.js': ['coach-response-generator'],
+    'visualization.js': ['coach-visualizer', 'motivational-images'],
+    'coach-personas.js': ['process-sms', 'signup'],
+    'reference-photo.js': ['account-deletion', 'coach-visualizer'],
+  };
+
+  /*
+    Some copies carry a leading "this is a duplicate, shared/ is the source of
+    truth" banner, which is a comment about provenance rather than a difference
+    in behaviour. Strip one leading block comment before comparing so the banner
+    stays allowed and everything after it still has to match exactly.
+  */
+  const body = (text) => text.replace(/^\uFEFF?\s*\/\*[\s\S]*?\*\/\s*/, '');
+
+  for (const [file, dirs] of Object.entries(DUPLICATED)) {
+    const sharedPath = path.join(REPO, 'functions/shared', file);
+    const shared = fs.existsSync(sharedPath) ? fs.readFileSync(sharedPath, 'utf8') : null;
+    check(`functions/shared/${file} exists`, shared !== null);
+    if (shared === null) continue;
+
+    for (const dir of dirs) {
+      const copy = path.join(REPO, 'functions', dir, file);
+      check(
+        `functions/${dir}/${file} is an exact copy of functions/shared/${file}`,
+        fs.existsSync(copy) && body(fs.readFileSync(copy, 'utf8')) === body(shared)
+      );
+    }
   }
+
+  // A shared module with no copy listed above is unguarded — catch that here
+  // rather than discovering it the next time one drifts.
+  const sharedDir = path.join(REPO, 'functions/shared');
+  const unguarded = fs.readdirSync(sharedDir)
+    .filter((f) => f.endsWith('.js') && !(f in DUPLICATED));
+  check(
+    'every module in functions/shared/ is covered by this table',
+    unguarded.length === 0,
+    unguarded.join(', ')
+  );
 }
 
 // ---------------------------------------------------------------------------

--- a/mobile/e2e/sms-image-probe.mjs
+++ b/mobile/e2e/sms-image-probe.mjs
@@ -33,7 +33,20 @@ const env = Object.fromEntries(
   })
 );
 
-const MOCK_MODEL = process.env.MOCK_OPENAI_URL || 'http://127.0.0.1:8791/v1/chat/completions';
+/*
+  `MOCK_OPENAI_URL` is also read by `harness/function-gateway.js`, which wants
+  the OpenAI *base* URL (`.../v1`) because the SDK appends the route itself.
+  This probe calls the endpoint directly, so it needs the full chat-completions
+  URL. One variable, two meanings: pointing this at the base URL makes every
+  model call 404, and a 404 here surfaces as ~20 unrelated-looking assertion
+  failures ("no scene was sent", "0 Replicate calls") rather than as a wiring
+  mistake. Accept either form so the same value works for both.
+*/
+const MOCK_MODEL = (() => {
+  const raw = process.env.MOCK_OPENAI_URL || 'http://127.0.0.1:8791/v1/chat/completions';
+  const trimmed = raw.replace(/\/+$/, '');
+  return /\/chat\/completions$/.test(trimmed) ? trimmed : `${trimmed}/chat/completions`;
+})();
 
 // The function reads these at require time.
 process.env.PROJECT_ID = 'local-test';

--- a/mobile/e2e/viz-realtime-probe.mjs
+++ b/mobile/e2e/viz-realtime-probe.mjs
@@ -263,25 +263,74 @@ section('Realtime: a coach-initiated message reaches an open thread');
   check('subscribed to the thread channel', subscribed);
 
   if (subscribed) {
+    /*
+      Wait for the event rather than sleeping a fixed interval. Realtime replays
+      the WAL in order, so when this suite runs straight after the write-heavy
+      ones it can still be chewing through their backlog when our insert lands —
+      a fixed 4s wait then reports "realtime is broken" for what is really a
+      queue that had not reached us yet. Poll to a generous ceiling instead: a
+      healthy stack satisfies this in well under a second, and a genuinely
+      broken one still fails, just later.
+    */
+    const waitFor = async (predicate, ms = 30000) => {
+      const deadline = Date.now() + ms;
+      while (Date.now() < deadline) {
+        if (predicate()) return true;
+        await new Promise((r) => setTimeout(r, 100));
+      }
+      return predicate();
+    };
+
     // Exactly what the nudge dispatcher does: a service-role assistant insert.
     await admin.from('conversation_messages').insert({
       conversation_id: conversationId, role: 'assistant',
       content: 'Morning. Twenty minutes on the kit today — what tempo?',
     });
 
-    await new Promise((r) => setTimeout(r, 4000));
+    await waitFor(() => received.length >= 1);
     check('the message arrived over realtime', received.length === 1, `received ${received.length}`);
     check('  → it is the coach turn', received[0]?.role === 'assistant', JSON.stringify(received[0]?.role));
     check('  → content intact', received[0]?.content?.includes('Twenty minutes'), received[0]?.content);
 
-    // Another member's thread must not leak through the same socket.
+    /*
+      Another member's thread must not leak through the same socket. Proving a
+      negative needs a positive to pin it to: subscribe as the other member too,
+      and wait for *their* channel to see the message. Once it has been
+      delivered there, realtime has demonstrably processed that insert, so
+      "nothing arrived on our channel" means it was filtered rather than merely
+      still in flight. A bare sleep here would pass just as happily against a
+      realtime server that had stopped delivering anything at all.
+    */
     const { data: other } = await admin.auth.admin.createUser({ email: `other${Date.now()}@example.com`, password: 'x-password-123', email_confirm: true });
-    const otherClient = createClient(env.API_URL, env.ANON_KEY, { auth: { persistSession: false } });
+    const otherClient = createClient(env.API_URL, env.ANON_KEY, {
+      auth: { persistSession: false },
+      realtime: { params: { eventsPerSecond: 10 } },
+    });
     await otherClient.auth.signInWithPassword({ email: other.user.email, password: 'x-password-123' });
     const otherConv = (await otherClient.rpc('open_coach_conversation', { p_coach_id: POCKET })).data;
+
+    const otherReceived = [];
+    const otherChannel = otherClient
+      .channel(`thread:${otherConv}`)
+      .on('postgres_changes', {
+        event: 'INSERT', schema: 'public', table: 'conversation_messages',
+        filter: `conversation_id=eq.${otherConv}`,
+      }, (payload) => otherReceived.push(payload.new));
+    const otherSubscribed = await new Promise((resolve) => {
+      otherChannel.subscribe((status) => {
+        if (status === 'SUBSCRIBED') resolve(true);
+        if (status === 'CHANNEL_ERROR' || status === 'TIMED_OUT') resolve(false);
+      });
+      setTimeout(() => resolve(false), 12000);
+    });
+    check('  → the other member subscribed to their own thread', otherSubscribed);
+
     await admin.from('conversation_messages').insert({ conversation_id: otherConv, role: 'assistant', content: 'not for you' });
-    await new Promise((r) => setTimeout(r, 3000));
+    const deliveredThere = await waitFor(() => otherReceived.length >= 1);
+    check('  → their message reached them', deliveredThere, `received ${otherReceived.length}`);
     check('another member\'s message did not leak in', received.length === 1, `received ${received.length}`);
+
+    await otherClient.removeChannel(otherChannel);
   }
 
   await user.removeChannel(channel);


### PR DESCRIPTION
Picks the fixable items out of the #40 handoff issue. Three of the facts that issue records were fixable in code rather than prose.

## Guard the duplicated prompt modules

Cloud Functions are zipped per-directory, so `require('../shared/...')` does not survive deploy and each function carries its own copy. The duplication is deliberate; the drift is not, and it has bitten before — a `coach.tagline` fix once landed in `functions/shared/` and never reached the deployed copy, which means a prompt change that silently does not apply in production looks exactly like a prompt change that did not work.

Only `crisis.js` and `visualization.js` were ever checked. The section in `crisis-probe.mjs` is now a table covering **all seven shared modules and all twelve copies**, plus an assertion that every module in `functions/shared/` appears in that table. That last check earned its keep immediately: it turned up `coach-personas.js` and `reference-photo.js` as unguarded.

Copies of `coach-personas.js` carry a "shared/ is the source of truth" banner and are otherwise byte-identical, so one leading block comment is stripped before comparing — the banner stays allowed, everything after it still has to match exactly.

## Fix the viz-realtime-probe flake

Running the full suite in sequence produced `29 passed, 4 failed` in `viz-realtime-probe.mjs`, all four in realtime delivery. It is not a regression. Realtime replays the WAL in order, and after the four write-heavy suites it was still draining their backlog when the probe's fixed 4-second wait expired. In isolation the same code gave 33/0.

The assertions now wait for delivery instead of sleeping. The no-leak assertion was the more interesting half: it asserted a negative against a bare sleep, which would pass just as happily against a realtime server that had stopped delivering anything at all. It is now pinned to a positive — the other member subscribes to their own thread, and we wait for the message to arrive *there* before asserting it did not arrive here. Once it has been delivered elsewhere, realtime has demonstrably processed that insert, so silence on our channel means filtered rather than in flight.

Verified by reproducing the original conditions: the four write-heavy suites back to back, then `viz-realtime-probe.mjs` immediately after. Was 29/4, now 35/0.

## Accept both meanings of MOCK_OPENAI_URL

`harness/function-gateway.js` wants the OpenAI *base* URL (`.../v1`) because the SDK appends the route itself. `sms-image-probe.mjs` calls the endpoint directly and wants `.../v1/chat/completions`. Same variable, two meanings.

Passing the gateway's form to the probe returns 404 on every model call, which surfaces as ~20 unrelated-looking assertion failures — "a scene was sent", "exactly one Replicate call — 0", "the image is about drums" — rather than as a wiring mistake. I lost a cycle to exactly this. Either form now works.

## Also

- **Deleted `saveSelectedAvatar`.** It took a `coachId` and an avatar URL from the request body and wrote them straight onto that row in `coach_profiles`, with no token check and no ownership check. Terraform never gave it an `entry_point`, so it was never deployed and never reachable — it was only waiting for someone to wire it up and ship an IDOR. A comment in its place explains what is missing if saving comes back.
- **README.** Said "Five suites" while listing seven, and omitted `creator-probe.mjs` from the run list. Documents the `MOCK_OPENAI_URL` ambiguity and the realtime ordering constraint.

The live exposure this does **not** fix — `coach-avatar-generator` itself is public, unauthenticated and burns Replicate credits — is #44. It needs a product decision rather than a patch, because `/coach-builder/*` is deliberately unauthenticated and requiring a session there would kill the top of the signup funnel.

## Verification

Local stack, all seven suites plus the model-free probe:

| Suite | Result |
| --- | --- |
| `rls-probe` | 77 / 0 |
| `club-probe` | 62 / 0 |
| `flow-probe` | 46 / 0 |
| `viz-realtime-probe` | 35 / 0 (was 33, +2 new checks) |
| `sms-image-probe` | 55 / 0 |
| `account-deletion-probe` | 64 / 0 |
| `creator-probe` | 39 / 0 |
| `prompt-eval/crisis-probe` | 143 / 0 |

378 checks across the seven, and `npx tsc --noEmit` clean from `mobile/`. `sms-image-probe` verified green under both `MOCK_OPENAI_URL` forms.

Does **not** close #40. That issue is a standing read-me-first for anyone picking up work here,
not a work item — closing it would hide it. Its body has been refreshed to match what this PR
changes, and every number in it re-measured on merged `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

