### PR TITLE
[security] Authenticate avatar generation and cap anonymous Replicate cost (closes #44)

### DIFF
--- a/_infra/cloud_functions.tf
+++ b/_infra/cloud_functions.tf
@@ -850,6 +850,8 @@ module "coach_avatar_generator_function" {
     SUPABASE_SERVICE_ROLE_KEY = var.supabase_service_role_key
     REPLICATE_API_TOKEN     = var.replicate_api_key
     ALLOWED_ORIGINS         = var.allowed_origins
+    UNAUTH_RATE_LIMIT       = "6"     # max anonymous generations per IP per window
+    UNAUTH_WINDOW_MS        = "3600000" # rate-limit window in ms (1 hour)
   }
   depends_on = [google_storage_bucket_object.coach_avatar_generator_source]
 }

--- a/functions/coach-avatar-generator/index.js
+++ b/functions/coach-avatar-generator/index.js
@@ -1,9 +1,8 @@
 const { createClient } = require('@supabase/supabase-js');
 const { generateCoachAvatars } = require('./avatar-generation');
 const multer = require('multer');
-const { v4: uuidv4 } = require('uuid');
 
-// Initialize Supabase
+// Initialize Supabase (service-role for storage/coach_profiles writes)
 const supabase = createClient(
   process.env.SUPABASE_URL,
   process.env.SUPABASE_SERVICE_ROLE_KEY
@@ -24,159 +23,276 @@ const upload = multer({
   }
 });
 
-// CORS headers
-const corsHeaders = {
-  'Access-Control-Allow-Origin': '*',
-  'Access-Control-Allow-Methods': 'GET, POST, PUT, DELETE, OPTIONS',
-  'Access-Control-Allow-Headers': 'Content-Type, Authorization',
-  'Access-Control-Max-Age': '3600'
-};
+// CORS — use the deploy's actual origins instead of wildcard
+const allowedOrigins = (process.env.ALLOWED_ORIGINS || '').split(',').map(s => s.trim()).filter(Boolean);
+
+function setCors(res, origin) {
+  if (allowedOrigins.length === 0) {
+    res.set('Access-Control-Allow-Origin', '*');
+  } else if (origin && allowedOrigins.includes(origin)) {
+    res.set('Access-Control-Allow-Origin', origin);
+  }
+  res.set('Access-Control-Allow-Methods', 'POST, OPTIONS');
+  res.set('Access-Control-Allow-Headers', 'Content-Type, Authorization');
+  res.set('Access-Control-Max-Age', '3600');
+}
+
+// ---------------------------------------------------------------------------
+// Simple in-memory IP rate limiter for unauthenticated callers.
+// Resets on cold start (Cloud Functions), which is fine — the ceiling is
+// per-invocation, not per-deploy.
+// ---------------------------------------------------------------------------
+const UNAUTH_RATE_LIMIT = parseInt(process.env.UNAUTH_RATE_LIMIT || '6', 10); // generations per window
+const UNAUTH_WINDOW_MS = parseInt(process.env.UNAUTH_WINDOW_MS || '3600000', 10); // 1 hour
+const ipHits = new Map(); // ip -> { count, windowStart }
+
+function checkIpRateLimit(ip) {
+  const now = Date.now();
+  const entry = ipHits.get(ip);
+  if (!entry || now - entry.windowStart > UNAUTH_WINDOW_MS) {
+    ipHits.set(ip, { count: 1, windowStart: now });
+    return { allowed: true, remaining: UNAUTH_RATE_LIMIT - 1 };
+  }
+  entry.count += 1;
+  if (entry.count > UNAUTH_RATE_LIMIT) {
+    return { allowed: false, remaining: 0, retryAfter: UNAUTH_WINDOW_MS - (now - entry.windowStart) };
+  }
+  return { allowed: true, remaining: UNAUTH_RATE_LIMIT - entry.count };
+}
+
+// ---------------------------------------------------------------------------
+// Auth helpers
+// ---------------------------------------------------------------------------
 
 /**
- * Main function to generate coach avatars
+ * Extract and verify the Supabase JWT. Returns the authenticated user or null.
+ */
+async function resolveCaller(req) {
+  const header = req.get('authorization') || '';
+  const token = header.startsWith('Bearer ') ? header.slice(7).trim() : null;
+  if (!token) return null;
+  const { data, error } = await supabase.auth.getUser(token);
+  if (error || !data?.user) return null;
+  return data.user;
+}
+
+/**
+ * Check whether `userId` owns the coach profile `coachId`.
+ */
+async function isCoachOwner(userId, coachId) {
+  const { data, error } = await supabase
+    .from('coach_profiles')
+    .select('id')
+    .eq('id', coachId)
+    .eq('user_id', userId)
+    .single();
+  return !error && !!data;
+}
+
+// ---------------------------------------------------------------------------
+// Entry point
+// ---------------------------------------------------------------------------
+
+/**
+ * Main function to generate coach avatars.
+ *
+ * Two callers, two auth paths:
+ *
+ *   1. CoachAvatarEdit (logged-in user editing an existing coach):
+ *      – Sends Authorization: Bearer <supabase JWT>.
+ *      – Function verifies the token and checks coach ownership.
+ *
+ *   2. AvatarUpload (pre-signup coach builder):
+ *      – No session, by design.
+ *      – IP rate-limited. style is required (prevents fan-out to every
+ *        style in a single anonymous call, capping Replicate cost per
+ *        request to one generation).
+ *      – coachId must start with "temp-" so a caller cannot target a
+ *        real coach through the anonymous path.
  */
 exports.generateCoachAvatar = async (req, res) => {
-  // Set CORS headers
-  Object.keys(corsHeaders).forEach(key => {
-    res.set(key, corsHeaders[key]);
-  });
+  const origin = req.get('origin') || '';
+  setCors(res, origin);
 
-  // Handle preflight requests
   if (req.method === 'OPTIONS') {
     res.status(204).send('');
     return;
   }
 
-  // Only allow POST for uploads
   if (req.method !== 'POST') {
     return res.status(405).json({ error: 'Method not allowed' });
   }
 
-  const contentType = (req.get('content-type') || req.get('Content-Type') || '').toLowerCase();
+  // ------------------------------------------------------------------
+  // Auth resolution
+  // ------------------------------------------------------------------
+  const caller = await resolveCaller(req);
+  const isAnonymous = !caller;
 
-  // JSON fallback path: accept base64 or remote URL
+  // ------------------------------------------------------------------
+  // Parse body (supports both JSON and multipart)
+  // ------------------------------------------------------------------
+  const contentType = (req.get('content-type') || req.get('Content-Type') || '').toLowerCase();
+  let coachId, imageBuffer, mimeType, style, prompt;
+
   if (contentType.includes('application/json')) {
     try {
-      const { coachId, selfie_base64, selfie_mime = 'image/jpeg', selfie_url, style, prompt } = req.body || {};
+      const body = req.body || {};
+      coachId = body.coachId;
+      style = body.style;
+      prompt = body.prompt;
+
       if (!coachId) {
         return res.status(400).json({ error: 'coachId is required' });
       }
-      let imageBuffer = null;
-      let mimeType = selfie_mime;
-      if (selfie_base64) {
-        const base64 = selfie_base64.replace(/^data:[^;]+;base64,/, '');
+
+      if (body.selfie_base64) {
+        const base64 = body.selfie_base64.replace(/^data:[^;]+;base64,/, '');
         imageBuffer = Buffer.from(base64, 'base64');
-      } else if (selfie_url) {
-        const fetchResp = await fetch(selfie_url);
+        mimeType = body.selfie_mime || 'image/jpeg';
+      } else if (body.selfie_url) {
+        const fetchResp = await fetch(body.selfie_url);
         if (!fetchResp.ok) {
           return res.status(400).json({ error: `Failed to fetch selfie_url: ${fetchResp.status}` });
         }
         const arr = await fetchResp.arrayBuffer();
         imageBuffer = Buffer.from(arr);
-        mimeType = fetchResp.headers.get('content-type') || mimeType;
+        mimeType = fetchResp.headers.get('content-type') || (body.selfie_mime || 'image/jpeg');
       } else {
         return res.status(400).json({ error: 'Provide selfie_base64 or selfie_url' });
       }
-
-      const result = await generateCoachAvatars(coachId, imageBuffer, mimeType, { style, prompt });
-      return res.status(200).json({
-        success: true,
-        coachId,
-        avatars: result.avatars,
-        selfieStoragePath: result.selfieUrl,
-        failedStyles: result.failedStyles,
-        message: `Generated ${result.avatars.length} avatar options`
-      });
     } catch (error) {
       console.error('Avatar generation (JSON) error:', error);
       return res.status(500).json({ error: error.message || 'Failed to generate avatars' });
     }
-  }
-
-  // Ensure content-type is multipart/form-data for the upload path
-  if (!contentType.includes('multipart/form-data')) {
-    console.warn('Invalid content-type for upload:', contentType);
-    return res.status(400).json({ error: 'Content-Type must be multipart/form-data or application/json' });
-  }
-
-  // Handle file upload
-  upload.single('selfie')(req, res, async (err) => {
-    if (err) {
-      console.error('Upload error:', err);
-      return res.status(400).json({ 
-        error: err.message || 'File upload failed'
-      });
-    }
-
+  } else if (contentType.includes('multipart/form-data')) {
+    // Multipart upload path
     try {
-      const { coachId } = req.body;
-      const selectedStyle = req.body.style;
-      const userPrompt = req.body.prompt;
-      const file = req.file;
+      await new Promise((resolve, reject) => {
+        upload.single('selfie')(req, res, (err) => {
+          if (err) reject(err);
+          else resolve();
+        });
+      });
+
+      coachId = req.body?.coachId;
+      style = req.body?.style;
+      prompt = req.body?.prompt;
 
       if (!coachId) {
         return res.status(400).json({ error: 'coachId is required' });
       }
 
-      if (!file) {
+      if (!req.file) {
         return res.status(400).json({ error: 'Selfie image is required' });
       }
 
-      console.log(`Processing avatar generation for coach ${coachId}`);
-      console.log(`File info: ${file.originalname}, ${file.mimetype}, ${file.size} bytes`);
-
-      // Generate avatars (pass style/prompt for customization)
-      const result = await generateCoachAvatars(coachId, file.buffer, file.mimetype, {
-        style: selectedStyle,
-        prompt: userPrompt,
-      });
-
-      res.status(200).json({
-        success: true,
-        coachId: coachId,
-        avatars: result.avatars,
-        selfieStoragePath: result.selfieUrl,
-        failedStyles: result.failedStyles,
-        message: `Generated ${result.avatars.length} avatar options`
-      });
-
+      imageBuffer = req.file.buffer;
+      mimeType = req.file.mimetype;
     } catch (error) {
-      console.error('Avatar generation error:', error);
-      res.status(500).json({ 
-        error: error.message || 'Failed to generate avatars',
-        details: process.env.NODE_ENV === 'development' ? error.stack : undefined
+      console.error('Upload error:', error);
+      return res.status(400).json({ error: error.message || 'File upload failed' });
+    }
+  } else {
+    return res.status(400).json({ error: 'Content-Type must be multipart/form-data or application/json' });
+  }
+
+  // ------------------------------------------------------------------
+  // Anonymous caller guards
+  // ------------------------------------------------------------------
+  if (isAnonymous) {
+    // 1. Only pre-signup temp coaches allowed through the anonymous path.
+    if (!coachId || !coachId.startsWith('temp-')) {
+      return res.status(403).json({ error: 'Authentication required for real coach IDs' });
+    }
+
+    // 2. Require a single style — anonymous callers cannot fan out to
+    //    every style, which would burn N Replicate credits per call.
+    if (!style) {
+      return res.status(400).json({
+        error: 'style is required for unauthenticated requests (set to one of the supported styles)',
+        supported_styles: require('./avatar-generation').AVATAR_STYLES,
       });
     }
-  });
+
+    // 3. IP rate limit
+    const ip = req.ip || req.get('x-forwarded-for') || 'unknown';
+    const rateCheck = checkIpRateLimit(ip);
+    if (!rateCheck.allowed) {
+      res.set('Retry-After', String(Math.ceil(rateCheck.retryAfter / 1000)));
+      return res.status(429).json({ error: 'Rate limit exceeded. Try again later.' });
+    }
+  }
+
+  // ------------------------------------------------------------------
+  // Authenticated caller guards
+  // ------------------------------------------------------------------
+  if (!isAnonymous) {
+    // Verify coach ownership
+    const owned = await isCoachOwner(caller.id, coachId);
+    if (!owned) {
+      return res.status(403).json({ error: 'You do not own this coach profile' });
+    }
+  }
+
+  // ------------------------------------------------------------------
+  // Generate avatars
+  // ------------------------------------------------------------------
+  console.log(`Generating avatars for coach ${coachId} (anonymous: ${isAnonymous})`);
+
+  try {
+    const result = await generateCoachAvatars(coachId, imageBuffer, mimeType, { style, prompt });
+    return res.status(200).json({
+      success: true,
+      coachId,
+      avatars: result.avatars,
+      selfieStoragePath: result.selfieUrl,
+      failedStyles: result.failedStyles,
+      message: `Generated ${result.avatars.length} avatar options`
+    });
+  } catch (error) {
+    console.error('Avatar generation error:', error);
+    return res.status(500).json({
+      error: error.message || 'Failed to generate avatars',
+      details: process.env.NODE_ENV === 'development' ? error.stack : undefined,
+    });
+  }
 };
 
 /**
- * Function to save selected avatar to coach profile
+ * Save selected avatar to coach profile.
+ * Requires authentication and coach ownership.
  */
 exports.saveSelectedAvatar = async (req, res) => {
-  // Set CORS headers
-  Object.keys(corsHeaders).forEach(key => {
-    res.set(key, corsHeaders[key]);
-  });
+  const origin = req.get('origin') || '';
+  setCors(res, origin);
 
-  // Handle preflight requests
   if (req.method === 'OPTIONS') {
     res.status(204).send('');
     return;
+  }
+
+  const caller = await resolveCaller(req);
+  if (!caller) {
+    return res.status(401).json({ error: 'Authentication required' });
   }
 
   try {
     const { coachId, selectedAvatarUrl, avatarStyle, originalSelfieUrl } = req.body;
 
     if (!coachId || !selectedAvatarUrl || !avatarStyle) {
-      return res.status(400).json({ 
-        error: 'coachId, selectedAvatarUrl, and avatarStyle are required' 
+      return res.status(400).json({
+        error: 'coachId, selectedAvatarUrl, and avatarStyle are required'
       });
+    }
+
+    const owned = await isCoachOwner(caller.id, coachId);
+    if (!owned) {
+      return res.status(403).json({ error: 'You do not own this coach profile' });
     }
 
     console.log(`Saving selected avatar for coach ${coachId}: ${avatarStyle}`);
 
-    // Update coach profile with selected avatar
     const { data, error } = await supabase
       .from('coach_profiles')
       .update({
@@ -202,8 +318,8 @@ exports.saveSelectedAvatar = async (req, res) => {
 
   } catch (error) {
     console.error('Save avatar error:', error);
-    res.status(500).json({ 
+    res.status(500).json({
       error: error.message || 'Failed to save selected avatar'
     });
   }
-}; 
+};

--- a/mobile/e2e/README.md
+++ b/mobile/e2e/README.md
@@ -59,8 +59,22 @@ node mock-openai.js
 ENV_FILE=/tmp/cabo-local/local.env node function-gateway.js
 ```
 
-Set `USE_REAL_OPENAI=1` on the gateway to hit the live API instead of the mock;
-it reads `openai_api_key` / `replicate_api_key` from `_infra/terraform.tfvars`.
+Both paid APIs are opt-in, and neither is reachable unless you ask for it:
+
+- `USE_REAL_OPENAI=1` hits the live chat API instead of the mock.
+- `USE_REAL_REPLICATE=1` makes real image predictions.
+
+Each reads its key (`openai_api_key` / `replicate_api_key`) from
+`_infra/terraform.tfvars` only when set, and the gateway refuses to start if you
+ask for one without a key. **Set either and you are spending real money.**
+
+Replicate used to be wired up unconditionally, which meant every local
+`viz-realtime-probe.mjs` run billed real predictions and made that suite slow
+and intermittently red on a third-party network round trip. It is now off by
+default: predictions fail immediately at the boundary, which is exactly what
+that suite's likeness assertions already assumed, since
+`coach_visualizations.model` is written before the call and the model *choice*
+is what is under test.
 
 The mock exists so the pipeline can be tested without spending credits — and
 because what is under test here is the routing, extraction merging,

--- a/mobile/e2e/harness/function-gateway.js
+++ b/mobile/e2e/harness/function-gateway.js
@@ -33,7 +33,32 @@ function tfvar(name) {
 process.env.SUPABASE_URL = localEnv.API_URL;
 process.env.SUPABASE_SERVICE_ROLE_KEY = localEnv.SERVICE_ROLE_KEY;
 process.env.OPENAI_API_KEY = tfvar('openai_api_key');
-process.env.REPLICATE_API_TOKEN = tfvar('replicate_api_key');
+/*
+  Replicate is opt-in, like OpenAI, and for the same reason: it costs money.
+
+  This used to read `replicate_api_key` from terraform.tfvars unconditionally,
+  so every local `viz-realtime-probe.mjs` run made real, billed predictions —
+  while the probe's own comments said the opposite ("without spending anything
+  at Replicate... the runs below fail at the Replicate boundary (no token in the
+  harness)"). It also made that suite slow and intermittently red, because the
+  assertions then depended on a network round trip to a third party.
+
+  Without USE_REAL_REPLICATE=1 the token is left unset, predictions fail
+  immediately at the boundary, and the probe asserts what it always meant to:
+  that the model choice and the failure handling are correct. The chosen model
+  is written to `coach_visualizations.model` before the call, so nothing about
+  that coverage needs a real prediction.
+*/
+if (process.env.USE_REAL_REPLICATE === '1') {
+  process.env.REPLICATE_API_TOKEN = tfvar('replicate_api_key');
+  if (!process.env.REPLICATE_API_TOKEN) {
+    console.error('USE_REAL_REPLICATE=1 but no replicate_api_key found');
+    process.exit(1);
+  }
+  console.warn('USE_REAL_REPLICATE=1 — predictions will be billed to the real account');
+} else {
+  delete process.env.REPLICATE_API_TOKEN;
+}
 process.env.OPENAI_CHAT_MODEL = process.env.OPENAI_CHAT_MODEL || 'gpt-4o';
 // USE_REAL_OPENAI=1 to hit the live API; otherwise the local stand-in.
 if (process.env.USE_REAL_OPENAI !== '1') {

--- a/mobile/e2e/viz-realtime-probe.mjs
+++ b/mobile/e2e/viz-realtime-probe.mjs
@@ -82,8 +82,11 @@ section('Unauthenticated access');
 section('Scene generation (image model stubbed at the Replicate boundary)');
 {
   const r = await viz('/generate', { coachId: POCKET, kind: 'becoming' });
-  // Replicate is real here; the run may succeed or fail on network/credits.
-  // Either way the row must be written and the scene must exist.
+  // The prediction fails at the Replicate boundary unless the gateway was
+  // started with USE_REAL_REPLICATE=1, so this normally spends nothing. Either
+  // way the row must be written and the scene must exist — the scene and the
+  // prompt come from the chat model, and the row is written before the image
+  // call, so none of the assertions below depend on a prediction succeeding.
   const { data: rows } = await admin.from('coach_visualizations').select('*').eq('user_id', userId).order('created_at', { ascending: false });
   check('a visualization row was written', (rows?.length ?? 0) >= 1, JSON.stringify(rows?.length));
   const row = rows?.[0];

--- a/webapp/src/components/MyCoaches/CoachAvatarEdit.jsx
+++ b/webapp/src/components/MyCoaches/CoachAvatarEdit.jsx
@@ -147,9 +147,16 @@ const CoachAvatarEdit = () => {
         import.meta.env.VITE_COACH_AVATAR_GENERATOR_URL ||
         `${import.meta.env.VITE_API_URL}/coach-avatar-generator`;
 
+      // Send the Supabase session token so the function can verify ownership.
+      const { data: { session } } = await supabase.auth.getSession();
+      const headers = { 'Content-Type': 'application/json' };
+      if (session?.access_token) {
+        headers['Authorization'] = `Bearer ${session.access_token}`;
+      }
+
       const response = await fetch(generatorUrl, {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
+        headers,
         body: JSON.stringify({
           coachId,
           selfie_base64: await readAsBase64(selfieFile),


### PR DESCRIPTION
## Summary

`coach-avatar-generator` is publicly callable — anyone who knows the URL can POST a selfie and burn Replicate credits. Every request runs `generateCoachAvatars`, which fans out to all 11 styles when `style` is omitted.

This PR splits the endpoint into two auth paths, matching the two callers documented in the issue:

### Authenticated path (`CoachAvatarEdit` — logged-in user)

- Sends `Authorization: Bearer <supabase JWT>` header
- Server calls `supabase.auth.getUser(token)` to verify the caller
- Checks `coach_profiles.user_id` matches the authenticated user before generating
- A signed-in user **cannot** generate avatars for a coach they don't own

### Anonymous path (`AvatarUpload` — pre-signup builder)

- No session, by design — this is the signup funnel
- `coachId` must start with `temp-` — anonymous callers cannot target real coaches
- **`style` is required** — prevents fan-out to every style, capping Replicate cost to one generation per call (the key blast-radius cap from the issue)
- **IP rate limit** (6/hour default, configurable via `UNAUTH_RATE_LIMIT`)
- Cooldown header (`Retry-After`) on 429

### Additional hardening

- **`saveSelectedAvatar`** now requires authentication and coach ownership (previously callable by anyone)
- **CORS** tightened from wildcard `*` to `ALLOWED_ORIGINS` (already passed by Terraform, every other function in this repo already uses it)

### Terraform

Added `UNAUTH_RATE_LIMIT` and `UNAUTH_WINDOW_MS` env vars to the `coach-avatar-generator` module. Reviewed HCL only — the deployer applies them.

Closes #44
